### PR TITLE
fixes #2 Add check for isSuppressed

### DIFF
--- a/src/reminders.js
+++ b/src/reminders.js
@@ -14,7 +14,7 @@ class BaseReminder {
   _getActiveEffectKeys(actor) {
     return actor
       ? actor.effects
-          .filter((effect) => !effect.data.disabled)
+          .filter((effect) => !effect.isSuppressed && !effect.data.disabled)
           .flatMap((effect) => effect.data.changes)
           .map((change) => change.key)
           .filter((key) => key.startsWith("flags.midi-qol."))


### PR DESCRIPTION
Active effects from unequipped items will have `isSuppressed = true`  but they weren't being ignored. Now check that property so we don't apply those effects.