### PR TITLE
Feat custom adv disadv

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
           download: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/module.zip
 
       # Create a zip file with all files required by the module to add to the release
-      - run: zip -r ./module.zip module.json LICENSE css/ src/ templates/
+      - run: zip -r ./module.zip module.json LICENSE css/ src/ templates/ languages/
 
       # Create a release for this specific version
       - name: Update Release with Files

--- a/css/adv-reminder.css
+++ b/css/adv-reminder.css
@@ -9,3 +9,16 @@
 .dialog .dialog-buttons button.default.critical {
   font-weight: bold;
 }
+
+.dialog .dialog-content div.custom-flags {
+    font-size: 12px;
+    margin: 10px 0;
+    padding: 5px;
+    border: 1px solid rgb(0, 0, 0, 0.2);
+    background-color:rgb(0, 0, 0, 0.05);
+}
+
+.dialog .dialog-content div.custom-flags ul:not(:first-child) {
+    border-top: 1px solid rgb(0, 0, 0, 0.2);
+    padding-top: 6px;
+}

--- a/languages/en.json
+++ b/languages/en.json
@@ -1,0 +1,6 @@
+{
+    "adv-reminder": {
+        "the-roll": "The roll",
+        "automatically-fails": "{rollString} automatically fails because of {effectLabel}."
+    }
+}

--- a/languages/en.json
+++ b/languages/en.json
@@ -1,6 +1,7 @@
 {
     "adv-reminder": {
         "the-roll": "The roll",
-        "automatically-fails": "{rollString} automatically fails because of {effectLabel}."
+        "automatically-fails": "{rollString} automatically fails because of {effectLabel}.",
+        "no-critical": "No critical"
     }
 }

--- a/languages/fr.json
+++ b/languages/fr.json
@@ -1,6 +1,7 @@
 {
     "adv-reminder": {
         "the-roll": "Le jet",
-        "automatically-fails": "{rollString} rate automatiquement à cause de l'effet : {effectLabel}."
+        "automatically-fails": "{rollString} rate automatiquement à cause de l'effet : {effectLabel}.",
+        "no-critical": "Critique impossible"
     }
 }

--- a/languages/fr.json
+++ b/languages/fr.json
@@ -1,0 +1,6 @@
+{
+    "adv-reminder": {
+        "the-roll": "Le jet",
+        "automatically-fails": "{rollString} rate automatiquement à cause de l'effet : {effectLabel}."
+    }
+}

--- a/module.json
+++ b/module.json
@@ -11,9 +11,27 @@
       "name": "lib-wrapper"
     }
   ],
-  "systems": ["dnd5e"],
-  "esmodules": ["src/module.js"],
-  "styles": ["css/adv-reminder.css"],
+  "systems": [
+    "dnd5e"
+  ],
+  "esmodules": [
+    "src/module.js"
+  ],
+  "styles": [
+    "css/adv-reminder.css"
+  ],
+  "languages": [
+    {
+      "lang": "en",
+      "name": "English",
+      "path": "languages/en.json"
+    },
+    {
+      "lang": "fr",
+      "name": "Français",
+      "path": "languages/fr.json"
+    }
+  ],
   "url": "https://github.com/kaelad02/adv-reminder",
   "manifest": "https://github.com/kaelad02/adv-reminder/releases/latest/download/module.json",
   "download": "https://github.com/kaelad02/adv-reminder/releases/download/v0.1/module.zip",

--- a/src/fails.js
+++ b/src/fails.js
@@ -11,7 +11,7 @@ class BaseFail {
   }
 
   get rollString() {
-    "The roll";
+    game.i18n.format("adv-reminder.the-roll");
   }
 
   failCheck() {

--- a/src/module.js
+++ b/src/module.js
@@ -76,7 +76,7 @@ function onRollAttack(wrapped, options) {
   debug("onRollAttack method called");
 
   // check for adv/dis flags unless the user pressed a fast-forward key
-  const isFF = isFastForwarding(options.event);
+  const isFF = isFastForwarding(options);
   if (isFF) {
     debug("held down a fast-foward key, skip checking for adv/dis");
   } else {
@@ -98,7 +98,7 @@ function onRollAbilitySave(wrapped, abilityId, options) {
   }
 
   // check for adv/dis flags unless the user pressed a fast-forward key
-  const isFF = isFastForwarding(options.event);
+  const isFF = isFastForwarding(options);
   if (isFF) {
     debug("held down a fast-foward key, skip checking for adv/dis");
   } else {
@@ -114,7 +114,7 @@ function onRollAbilityTest(wrapped, abilityId, options) {
   debug("onRollAbilityTest method called");
 
   // check for adv/dis flags unless the user pressed a fast-forward key
-  const isFF = isFastForwarding(options.event);
+  const isFF = isFastForwarding(options);
   if (isFF) {
     debug("held down a fast-foward key, skip checking for adv/dis");
   } else {
@@ -130,7 +130,7 @@ function onRollSkill(wrapped, skillId, options) {
   debug("onRollSkill method called");
 
   // check for adv/dis flags unless the user pressed a fast-forward key
-  const isFF = isFastForwarding(options.event);
+  const isFF = isFastForwarding(options);
   if (isFF) {
     debug("held down a fast-foward key, skip checking for adv/dis");
   } else {
@@ -146,7 +146,7 @@ function onRollToolCheck(wrapped, options) {
   debug("onRollToolCheck method called");
 
   // check for adv/dis flags unless the user pressed a fast-forward key
-  const isFF = isFastForwarding(options.event);
+  const isFF = isFastForwarding(options);
   if (isFF) {
     debug("held down a fast-foward key, skip checking for adv/dis");
   } else {
@@ -165,7 +165,7 @@ function onRollDeathSave(wrapped, options) {
   debug("onRollDeathSave method called");
 
   // check for adv/dis flags unless the user pressed a fast-forward key
-  const isFF = isFastForwarding(options.event);
+  const isFF = isFastForwarding(options);
   if (isFF) {
     debug("held down a fast-foward key, skip checking for adv/dis");
   } else {
@@ -181,7 +181,7 @@ function onRollDamage(wrapped, options) {
   debug("onRollDamage method called");
 
   // check for critical flags unless the user pressed a fast-forward key
-  const isFF = isFastForwarding(options.event);
+  const isFF = isFastForwarding(options);
   if (isFF) {
     debug("held down a fast-foward key, skip checking for adv/dis");
   } else {
@@ -198,8 +198,8 @@ function onRollDamage(wrapped, options) {
  * @param {Event} event the event
  * @returns {Boolean} true if they are fast-forwarding, false otherwise
  */
-function isFastForwarding(event) {
-  return event?.shiftKey || event?.altKey || event?.ctrlKey || event?.metaKey;
+function isFastForwarding(options) {
+  return !!(options.fastForward || options.event?.shiftKey || options.event?.altKey || options.event?.ctrlKey || options.event?.metaKey);
 }
 
 /**

--- a/src/module.js
+++ b/src/module.js
@@ -222,13 +222,20 @@ function getTarget() {
  * @param {Object} options the object created while parsing the effects flags
  */
 function createRenderDialogHook(options) {
+  const id = options.dialogOptions?.id || options.options?.dialogOptions?.id;
+  if (!id) return;
+
   const callback = (dialog, html) => {
-    if (dialog.options.id !== (options.dialogOptions?.id || options.options?.dialogOptions?.id)) return;
+    if (dialog.options.id !== id) return;
     rollDialogUpdater(dialog, html, options);
     Hooks.off("renderDialog", callback);
   }
 
-  Hooks.on("renderDialog", callback);
+  const hookId = Hooks.on("renderDialog", callback);
+
+  setTimeout(() => {
+    Hooks.off("renderDialog", hookId);
+  }, 10_000);
 }
 
 /**

--- a/src/reminders.js
+++ b/src/reminders.js
@@ -53,6 +53,9 @@ class BaseReminder {
         // add custom adv and dis arrays even if empty
         options.customAdvantages = customAdvantages;
         options.customDisadvantages = customDisadvantages;
+
+        // add an html id (should be unique) to the roll dialog window
+        options.dialogOptions = mergeObject(options.dialogOptions || {}, { id: randomID() });
       },
     };
   }
@@ -324,6 +327,9 @@ export class CriticalReminder extends BaseReminder {
         // add custom crits and normals arrays even if empty
         options.customCrits = customCrits;
         options.customNormals = customNormals;
+
+        // add an html id (should be unique) to the roll dialog window
+        options.options = mergeObject(options.options || {}, { dialogOptions: { id: randomID() } });
       },
     };
   }

--- a/templates/fail-chat-card.html
+++ b/templates/fail-chat-card.html
@@ -6,7 +6,7 @@
     </header>
 
     <div class="card-content">
-        <p>{{ rollString }} <b>automatically fails</b> because of {{effectData.label}}. </p>
+        <p>{{ localize "adv-reminder.automatically-fails" rollString=rollString effectLabel=effectData.label }}. </p>
     </div>
 
 </div>

--- a/test/reminders.test.js
+++ b/test/reminders.test.js
@@ -85,6 +85,11 @@ function createEffect(key) {
           value: "1",
           mode: 0,
           priority: "0",
+          document: {
+            data: {
+              label: `label.${key}`
+            }
+          }
         },
       ],
       disabled: false,


### PR DESCRIPTION
Hello,

This is my attempt to solve: https://github.com/kaelad02/adv-reminder/issues/3
Although, I'm stuck. Maybe you can find a solution (see below).

**1st Commit: Localization**
Simple localization. Not much to say.

**2nd commit: Compatibility with MRE**
Just a simple change for this module to be compatible with MRE (https://github.com/ElfFriend-DnD/FVTT-Minimal-Rolling-Enhancements-DND5E).
MRE, like this module, is low automation oriented. It just fast-forwards rolls. This change is to catch the MRE fast-forwards (with a `fastForward` property added by MRE in the options object)

**3rd Commit: Store and retrieve custom flags**
The good stuff. Basically, all keys that are existing also exist with the prefix `custom.`
If such a key is found in the actor's effects and also has a value, then it is added to an array.

There are 4 arrays:
- customAdvantages
- customDisadvantages
- customCrits
- customNormals

Those 4 arrays are then sent as part of the `options` object of the roll.

Note that I changed the naming of a few variables and method to better reflect the overall features.
Also, I prepare the origin actor effects object with more than just the keys, but also the value of a change and the label of the parent effect (so we can display all of that in the 5e Roll Dialog)

**The "help, I'm stuck" part: getting FVTT to display the custom flags**
So, the objective is to display the custom flags like this:

![image](https://user-images.githubusercontent.com/1687854/150617995-edb0d132-ccc7-419a-8ddc-2301d6c997db.png)

I've tried two ways of doing it:
1. Wrapping/overriding 5e class/methods/functions. Well, beside overriding a tone of 5e methods (yuck), I'm not even sure this is possible. Some functions that are part of the process are not even exposed by the system (correct me if I'm wrong).
2. Using the `Hook.once("renderDialog", () => {})` to catch the next dialog opened. Working great, until two windows opens at the same time. That happens in rare cases, but it still happens. And when it happens, it goes "boum".

So, I'm now stuck on that part. Maybe you can take a shot at it? Fresh eyes might solve the puzzle.

In case, you need this.
Here is the added template part I used for the roll window:
```handlebars
<form>
    [...]
    <div class="custom-flags">
        {{#if customAdvantages}}
            <ul>
                {{#each customAdvantages}}
                    <li><b>{{ localize "DND5E.Advantage" }} :</b> {{ value }} ({{ label }})</li>
                {{/each}}
            </ul>
        {{/if}}
        {{#if customDisadvantages}}
            <ul>
                {{#each customDisadvantages}}
                    <li><b>{{ localize "DND5E.Disadvantage" }} :</b> {{ value }} ({{ label }})</li>
                {{/each}}
            </ul>
        {{/if}}
        {{#if customCrits}}
            <ul>
                {{#each customCrits}}
                    <li><b>{{ localize "DND5E.CriticalHit" }} :</b> {{ value }} ({{ label }})</li>
                {{/each}}
            </ul>
        {{/if}}
        {{#if customNormals}}
            <ul>
                {{#each customNormals}}
                    <li><b>{{ localize "adv-reminder.no-critical" }} :</b> {{ value }} ({{ label }})</li>
                {{/each}}
            </ul>
        {{/if}}
    </div>
</form>
```

The CSS that goes with it:
```css
.dialog .dialog-content div.custom-flags {
    font-size: 12px;
    margin: 10px 0;
    padding: 5px;
    border: 1px solid rgb(0, 0, 0, 0.2);
    background-color:rgb(0, 0, 0, 0.05);
}

.dialog .dialog-content div.custom-flags ul:not(:first-child) {
    border-top: 1px solid rgb(0, 0, 0, 0.2);
    padding-top: 6px;
}
```

And the localization keys:
```
[EN] "no-critical": "No critical"
[FR] "no-critical": "Critique impossible"
```

Hope you can make something of this!