### PR TITLE
Compatibility with MRE's fastForward

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -76,7 +76,7 @@ function onRollAttack(wrapped, options) {
   debug("onRollAttack method called");
 
   // check for adv/dis flags unless the user pressed a fast-forward key
-  const isFF = isFastForwarding(options.event);
+  const isFF = isFastForwarding(options);
   if (isFF) {
     debug("held down a fast-foward key, skip checking for adv/dis");
   } else {
@@ -98,7 +98,7 @@ function onRollAbilitySave(wrapped, abilityId, options) {
   }
 
   // check for adv/dis flags unless the user pressed a fast-forward key
-  const isFF = isFastForwarding(options.event);
+  const isFF = isFastForwarding(options);
   if (isFF) {
     debug("held down a fast-foward key, skip checking for adv/dis");
   } else {
@@ -114,7 +114,7 @@ function onRollAbilityTest(wrapped, abilityId, options) {
   debug("onRollAbilityTest method called");
 
   // check for adv/dis flags unless the user pressed a fast-forward key
-  const isFF = isFastForwarding(options.event);
+  const isFF = isFastForwarding(options);
   if (isFF) {
     debug("held down a fast-foward key, skip checking for adv/dis");
   } else {
@@ -130,7 +130,7 @@ function onRollSkill(wrapped, skillId, options) {
   debug("onRollSkill method called");
 
   // check for adv/dis flags unless the user pressed a fast-forward key
-  const isFF = isFastForwarding(options.event);
+  const isFF = isFastForwarding(options);
   if (isFF) {
     debug("held down a fast-foward key, skip checking for adv/dis");
   } else {
@@ -146,7 +146,7 @@ function onRollToolCheck(wrapped, options) {
   debug("onRollToolCheck method called");
 
   // check for adv/dis flags unless the user pressed a fast-forward key
-  const isFF = isFastForwarding(options.event);
+  const isFF = isFastForwarding(options);
   if (isFF) {
     debug("held down a fast-foward key, skip checking for adv/dis");
   } else {
@@ -165,7 +165,7 @@ function onRollDeathSave(wrapped, options) {
   debug("onRollDeathSave method called");
 
   // check for adv/dis flags unless the user pressed a fast-forward key
-  const isFF = isFastForwarding(options.event);
+  const isFF = isFastForwarding(options);
   if (isFF) {
     debug("held down a fast-foward key, skip checking for adv/dis");
   } else {
@@ -181,7 +181,7 @@ function onRollDamage(wrapped, options) {
   debug("onRollDamage method called");
 
   // check for critical flags unless the user pressed a fast-forward key
-  const isFF = isFastForwarding(options.event);
+  const isFF = isFastForwarding(options);
   if (isFF) {
     debug("held down a fast-foward key, skip checking for adv/dis");
   } else {
@@ -198,8 +198,8 @@ function onRollDamage(wrapped, options) {
  * @param {Event} event the event
  * @returns {Boolean} true if they are fast-forwarding, false otherwise
  */
-function isFastForwarding(event) {
-  return event?.shiftKey || event?.altKey || event?.ctrlKey || event?.metaKey;
+function isFastForwarding(options) {
+  return !!(options.fastForward || options.event?.shiftKey || options.event?.altKey || options.event?.ctrlKey || options.event?.metaKey);
 }
 
 /**


### PR DESCRIPTION
MRE can add fastForward to the roll options so check that when detecting if the call is fast-forwarded to skip our checks.