### PR TITLE
Add player setting to style the buttons and messages

### DIFF
--- a/css/adv-reminder.css
+++ b/css/adv-reminder.css
@@ -9,7 +9,10 @@
 }
 
 /* Style the default buttons */
-.dialog .dialog-buttons button.default {
+.dialog .dialog-buttons button.default.normal,
+.dialog .dialog-buttons button.default.advantage,
+.dialog .dialog-buttons button.default.disadvantage,
+.dialog .dialog-buttons button.default.critical {
   background-color: var(--adv-reminder-color-green-5pct);
   border-color: var(--adv-reminder-color-green);
   color: var(--adv-reminder-color-green);

--- a/css/adv-reminder.css
+++ b/css/adv-reminder.css
@@ -1,11 +1,20 @@
 :root {
+  --adv-reminder-color: #191813; /* copied from --color-text-dark-primary */
+  --adv-reminder-background-color: rgba(0, 0, 0, 0.05);
+  --adv-reminder-button-border-color: #c9c7b8;  /* copied from --color-border-light-secondary */
+  --adv-reminder-message-border-color: #7a7971; /* copied from --color-border-light-tertiary */
+  /* None */
+  --adv-reminder-none-color: #191813; /* copied from --color-text-dark-primary */
+  --adv-reminder-none-background-color: rgba(0, 0, 0, 0.05);
+  --adv-reminder-none-button-border-color: #c9c7b8;  /* copied from --color-border-light-secondary */
+  --adv-reminder-none-message-border-color: #7a7971; /* copied from --color-border-light-tertiary */
+  /* Orange TODO*/
   --adv-reminder-color-orange: #ff6400;
-  --adv-reminder-color-orange-light: rgba(255, 100, 0, 0.1);
-  --adv-reminder-color-green: green;
-  --adv-reminder-color-green-5pct: rgba(0, 128, 0, 0.05);
-  --adv-reminder-color-green-10pct: rgb(0, 128, 0, 0.1);
-  --adv-reminder-color-green-15pct: rgb(0, 128, 0, 0.15);
-  --adv-reminder-color-green-msg: #bed0be;
+  /* Green */
+  --adv-reminder-green-color: green;
+  --adv-reminder-green-background-color: rgba(0, 128, 0, 0.05);
+  --adv-reminder-green-button-border-color: green;
+  --adv-reminder-green-message-border-color: green;
 }
 
 /* Style the default buttons */
@@ -13,32 +22,32 @@
 .dialog .dialog-buttons button.default.advantage,
 .dialog .dialog-buttons button.default.disadvantage,
 .dialog .dialog-buttons button.default.critical {
-  background-color: var(--adv-reminder-color-green-5pct);
-  border-color: var(--adv-reminder-color-green);
-  color: var(--adv-reminder-color-green);
+  background-color: var(--adv-reminder-background-color);
+  border-color: var(--adv-reminder-button-border-color);
+  color: var(--adv-reminder-color);
   font-weight: bold;
 }
 
 /* Style the messages */
 .dialog .dialog-content .adv-reminder-messages {
-  background-color: var(--adv-reminder-color-green-5pct);
+  background-color: var(--adv-reminder-background-color);
   padding: 5px 5px;
   margin: 8px 0;
-  color: var(--adv-reminder-color-green);
-  border: 1px solid var(--adv-reminder-color-green);
+  color: var(--adv-reminder-color);
+  border: 1px solid var(--adv-reminder-message-border-color);
   border-radius: 3px;
 }
 .adv-reminder-messages > div:not(:last-child) {
   margin-bottom: 10px;
 }
 .adv-reminder-messages a.content-link {
-  border-color: var(--adv-reminder-color-green);
+  border-color: var(--adv-reminder-message-border-color);
 }
 /* Copy the style from "inline-roll" to "dialog-roll" */
 .adv-reminder-messages a.dialog-roll {
   background: #ddd;
   padding: 1px 4px;
-  border: 1px solid var(--adv-reminder-color-green);
+  border: 1px solid var(--adv-reminder-message-border-color);
   border-radius: 2px;
   white-space: nowrap;
   word-break: break-all;

--- a/css/adv-reminder.css
+++ b/css/adv-reminder.css
@@ -1,36 +1,45 @@
-/* Style the default buttons that aren't normal */
-.dialog .dialog-buttons button.default.advantage {
-  font-weight: bold;
+:root {
+  --adv-reminder-color-orange: #ff6400;
+  --adv-reminder-color-orange-light: rgba(255, 100, 0, 0.1);
+  --adv-reminder-color-green: green;
+  --adv-reminder-color-green-5pct: rgba(0, 128, 0, 0.05);
+  --adv-reminder-color-green-10pct: rgb(0, 128, 0, 0.1);
+  --adv-reminder-color-green-15pct: rgb(0, 128, 0, 0.15);
+  --adv-reminder-color-green-msg: #bed0be;
 }
-.dialog .dialog-buttons button.default.disadvantage {
-  font-weight: bold;
-}
-.dialog .dialog-buttons button.default.critical {
+
+/* Style the default buttons */
+.dialog .dialog-buttons button.default {
+  background-color: var(--adv-reminder-color-green-5pct);
+  border-color: var(--adv-reminder-color-green);
+  color: var(--adv-reminder-color-green);
   font-weight: bold;
 }
 
 /* Style the messages */
 .dialog .dialog-content .adv-reminder-messages {
-  background: rgba(0, 0, 0, 0.05);
-  padding: 3px 5px;
+  background-color: var(--adv-reminder-color-green-5pct);
+  padding: 5px 5px;
   margin: 8px 0;
-  color: #191813;
-  border: 1px solid #7a7971;
+  color: var(--adv-reminder-color-green);
+  border: 1px solid var(--adv-reminder-color-green);
   border-radius: 3px;
 }
 .adv-reminder-messages > div:not(:last-child) {
   margin-bottom: 10px;
 }
-
+.adv-reminder-messages a.content-link {
+  border-color: var(--adv-reminder-color-green);
+}
 /* Copy the style from "inline-roll" to "dialog-roll" */
-a.dialog-roll {
+.adv-reminder-messages a.dialog-roll {
   background: #ddd;
   padding: 1px 4px;
-  border: 1px solid var(--color-border-dark-tertiary);
+  border: 1px solid var(--adv-reminder-color-green);
   border-radius: 2px;
   white-space: nowrap;
   word-break: break-all;
 }
-a.dialog-roll i {
+.adv-reminder-messages a.dialog-roll i {
   color: var(--color-text-dark-inactive);
 }

--- a/css/adv-reminder.css
+++ b/css/adv-reminder.css
@@ -3,18 +3,6 @@
   --adv-reminder-background-color: rgba(0, 0, 0, 0.05);
   --adv-reminder-button-border-color: #c9c7b8;  /* copied from --color-border-light-secondary */
   --adv-reminder-message-border-color: #7a7971; /* copied from --color-border-light-tertiary */
-  /* None */
-  --adv-reminder-none-color: #191813; /* copied from --color-text-dark-primary */
-  --adv-reminder-none-background-color: rgba(0, 0, 0, 0.05);
-  --adv-reminder-none-button-border-color: #c9c7b8;  /* copied from --color-border-light-secondary */
-  --adv-reminder-none-message-border-color: #7a7971; /* copied from --color-border-light-tertiary */
-  /* Orange TODO*/
-  --adv-reminder-color-orange: #ff6400;
-  /* Green */
-  --adv-reminder-green-color: green;
-  --adv-reminder-green-background-color: rgba(0, 128, 0, 0.05);
-  --adv-reminder-green-button-border-color: green;
-  --adv-reminder-green-message-border-color: green;
 }
 
 /* Style the default buttons */

--- a/lang/en.json
+++ b/lang/en.json
@@ -1,3 +1,7 @@
 {
-  "adv-reminder.AutoFail": "Auto fail"
+  "adv-reminder.AutoFail": "Auto fail",
+  "adv-reminder.DefaultButtonColor": "Default button color",
+  "adv-reminder.None": "No color change",
+  "adv-reminder.Player": "Player color",
+  "adv-reminder.Green": "Green"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -1,7 +1,16 @@
 {
   "adv-reminder.AutoFail": "Auto fail",
-  "adv-reminder.DefaultButtonColor": "Default button color",
-  "adv-reminder.None": "No color change",
-  "adv-reminder.Player": "Player color",
-  "adv-reminder.Green": "Green"
+  "adv-reminder.DefaultButtonColor": {
+    "Name": "Default button color",
+    "Hint": "Colors the text and tints the background of the buttons and messages.",
+    "None": "No color change",
+    "Player": "Player color",
+    "Green": "Green",
+    "Orange": "Orange",
+    "CustomColor": "Custom color"
+  },
+  "adv-reminder.CustomColor": {
+    "Name": "Custom Color",
+    "Hint": "Dark colors work better than light colors"
+  }
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -6,7 +6,7 @@
     "None": "No color change",
     "Player": "Player color",
     "Green": "Green",
-    "CustomColor": "Custom color"
+    "Custom": "Custom color"
   },
   "adv-reminder.CustomColor": {
     "Name": "Custom Color",

--- a/lang/en.json
+++ b/lang/en.json
@@ -6,7 +6,6 @@
     "None": "No color change",
     "Player": "Player color",
     "Green": "Green",
-    "Orange": "Orange",
     "CustomColor": "Custom color"
   },
   "adv-reminder.CustomColor": {

--- a/module.json
+++ b/module.json
@@ -24,7 +24,7 @@
     }
   ],
   "systems": ["dnd5e", "sw5e"],
-  "esmodules": ["src/module.js"],
+  "esmodules": ["src/module.js", "src/settings.js"],
   "styles": ["css/adv-reminder.css"],
   "url": "https://github.com/kaelad02/adv-reminder",
   "manifest": "https://github.com/kaelad02/adv-reminder/releases/latest/download/module.json",

--- a/src/module.js
+++ b/src/module.js
@@ -15,15 +15,12 @@ import {
   DeathSaveReminder,
   SkillReminder,
 } from "./reminders.js";
-import { registerSettings, fetchSettings, initDefaultButtonColor } from "./settings.js";
 import { debug, isMinVersion, log } from "./util.js";
 
 let checkArmorStealth;
 
 Hooks.once("init", () => {
   log("initializing Advantage Reminder");
-  registerSettings();
-  fetchSettings();
 
   // DAE version 0.8.81 added support for "impose stealth disadvantage"
   checkArmorStealth = !isMinVersion("dae", "0.8.81");
@@ -92,8 +89,6 @@ Hooks.once("init", () => {
 // Add message flags to DAE so it shows them in the AE editor. Should do this in
 // a setup hook, but this module is loaded before DAE so do it in ready instead.
 Hooks.once("ready", () => {
-  initDefaultButtonColor();
-
   if (game.modules.get("dae")?.active) {
     const fields = [];
     fields.push("flags.adv-reminder.message.all");

--- a/src/module.js
+++ b/src/module.js
@@ -15,7 +15,7 @@ import {
   DeathSaveReminder,
   SkillReminder,
 } from "./reminders.js";
-import { registerSettings, fetchSettings } from "./settings.js";
+import { registerSettings, fetchSettings, initDefaultButtonColor } from "./settings.js";
 import { debug, isMinVersion, log } from "./util.js";
 
 let checkArmorStealth;
@@ -92,6 +92,8 @@ Hooks.once("init", () => {
 // Add message flags to DAE so it shows them in the AE editor. Should do this in
 // a setup hook, but this module is loaded before DAE so do it in ready instead.
 Hooks.once("ready", () => {
+  initDefaultButtonColor();
+
   if (game.modules.get("dae")?.active) {
     const fields = [];
     fields.push("flags.adv-reminder.message.all");

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,17 +1,5 @@
-export var debugEnabled;
-
 Hooks.once("init", () => {
   // register settings
-  game.settings.register("adv-reminder", "debugLogging", {
-    name: "Debug logging",
-    scope: "world",
-    config: false,
-    type: Boolean,
-    default: false,
-    onChange: (value) => {
-      debugEnabled = value;
-    },
-  });
   game.settings.register("adv-reminder", "defaultButtonColor", {
     name: "adv-reminder.DefaultButtonColor.Name",
     hint: "adv-reminder.DefaultButtonColor.Hint",
@@ -44,9 +32,6 @@ Hooks.once("init", () => {
         customColor
       ),
   });
-
-  // initialize settings
-  debugEnabled = game.settings.get("adv-reminder", "debugLogging");
 });
 
 Hooks.once("ready", () => {
@@ -56,6 +41,10 @@ Hooks.once("ready", () => {
     game.settings.get("adv-reminder", "customColor")
   );
 });
+
+Hooks.once("devModeReady", ({ registerPackageDebugFlag }) =>
+  registerPackageDebugFlag("adv-reminder")
+);
 
 function setStyleVariables(option, customColor) {
   // set four color variables based on the option

--- a/src/settings.js
+++ b/src/settings.js
@@ -11,8 +11,116 @@ export const registerSettings = function () {
       debugEnabled = value;
     },
   });
+
+  game.settings.register("adv-reminder", "defaultButtonColor", {
+    name: "adv-reminder.DefaultButtonColor.Name",
+    hint: "adv-reminder.DefaultButtonColor.Hint",
+    scope: "client",
+    config: true,
+    type: String,
+    choices: {
+      none: "adv-reminder.DefaultButtonColor.None",
+      player: "adv-reminder.DefaultButtonColor.Player",
+      green: "adv-reminder.DefaultButtonColor.Green",
+      orange: "adv-reminder.DefaultButtonColor.Orange",
+      custom: "adv-reminder.DefaultButtonColor.CustomColor",
+    },
+    default: "none",
+    onChange: setStyleVariables,
+  });
+
+  game.settings.register("adv-reminder", "customColor", {
+    name: "adv-reminder.CustomColor.Name",
+    hint: "adv-reminder.CustomColor.Hint",
+    scope: "client",
+    config: true,
+    type: String,
+    default: "#000000",
+  });
 };
 
 export const fetchSettings = function () {
   debugEnabled = game.settings.get("adv-reminder", "debugLogging");
 };
+
+export const initDefaultButtonColor = function () {
+  setStyleVariables(game.settings.get("adv-reminder", "defaultButtonColor"));
+};
+
+function setStyleVariables(option) {
+  // set four color variables based on the option
+  var varColor, varBackground, varButtonBorder, varMessageBorder;
+  const setColorVars = (color) => {
+    varColor = color;
+    varBackground = hexToRGBAString(colorStringToHex(color), 0.05);
+    varButtonBorder = color;
+    varMessageBorder = color;
+  };
+  switch (option) {
+    case "none":
+      varColor = "#191813";
+      varBackground = "rgba(0, 0, 0, 0.05)";
+      varButtonBorder = "#c9c7b8";
+      varMessageBorder = "#7a7971";
+      break;
+    case "player":
+      setColorVars(game.user.color);
+      break;
+    case "green":
+      setColorVars("#008000");
+      break;
+    case "orange":
+      setColorVars("#ff6400");
+      break;
+    case "custom":
+      // TODO
+      break;
+  }
+
+  const root = document.querySelector(":root");
+  const setStyle = (varName, value) => root.style.setProperty(varName, value);
+  setStyle("--adv-reminder-color", varColor);
+  setStyle("--adv-reminder-background-color", varBackground);
+  setStyle("--adv-reminder-button-border-color", varButtonBorder);
+  setStyle("--adv-reminder-message-border-color", varMessageBorder);
+}
+
+Hooks.on("renderSettingsConfig", (app, html, data) => {
+  // Create color picker
+  const settingId = "adv-reminder.customColor";
+  const customColor = game.settings.get("adv-reminder", "customColor");
+  const colorPickerElement = document.createElement("input");
+  colorPickerElement.setAttribute("type", "color");
+  colorPickerElement.setAttribute("data-edit", settingId);
+  colorPickerElement.value = customColor;
+
+  // Add color picker
+  const stringInputElement = html[0].querySelector(
+    `input[name="${settingId}"]`
+  );
+  stringInputElement.classList.add("color");
+  stringInputElement.after(colorPickerElement);
+
+  // Enable/disable customColor inputs
+  const disableCustomColor = (optionValue) => {
+    const input1 = document.querySelector(`input[name="${settingId}"]`);
+    const input2 = document.querySelector(`input[data-edit="${settingId}"]`);
+
+    if (optionValue === "custom") {
+      input1.removeAttribute("disabled");
+      input2.removeAttribute("disabled");
+    } else {
+      input1.setAttribute("disabled", true);
+      input2.setAttribute("disabled", true);
+    }
+  };
+  disableCustomColor(game.settings.get("adv-reminder", "defaultButtonColor"));
+
+  // Add click listener to enable/disable customColor inputs
+  const optionElement = html[0].querySelector(
+    `select[name="adv-reminder.defaultButtonColor"]`
+  );
+  optionElement.addEventListener("click", (event) =>
+    disableCustomColor(event.target.value)
+  );
+});

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,6 +1,7 @@
 export var debugEnabled;
 
-export const registerSettings = function () {
+Hooks.once("init", () => {
+  // register settings
   game.settings.register("adv-reminder", "debugLogging", {
     name: "Debug logging",
     scope: "world",
@@ -11,7 +12,6 @@ export const registerSettings = function () {
       debugEnabled = value;
     },
   });
-
   game.settings.register("adv-reminder", "defaultButtonColor", {
     name: "adv-reminder.DefaultButtonColor.Name",
     hint: "adv-reminder.DefaultButtonColor.Hint",
@@ -31,7 +31,6 @@ export const registerSettings = function () {
         game.settings.get("adv-reminder", "customColor")
       ),
   });
-
   game.settings.register("adv-reminder", "customColor", {
     name: "adv-reminder.CustomColor.Name",
     hint: "adv-reminder.CustomColor.Hint",
@@ -45,18 +44,18 @@ export const registerSettings = function () {
         customColor
       ),
   });
-};
 
-export const fetchSettings = function () {
+  // initialize settings
   debugEnabled = game.settings.get("adv-reminder", "debugLogging");
-};
+});
 
-export const initDefaultButtonColor = function () {
+Hooks.once("ready", () => {
+  // initialize the color variables
   setStyleVariables(
     game.settings.get("adv-reminder", "defaultButtonColor"),
     game.settings.get("adv-reminder", "customColor")
   );
-};
+});
 
 function setStyleVariables(option, customColor) {
   // set four color variables based on the option
@@ -93,6 +92,9 @@ function setStyleVariables(option, customColor) {
   setStyle("--adv-reminder-message-border-color", varMessageBorder);
 }
 
+/**
+ * Customize the settings dialog to handle the custom color (hide/show and color picker)
+ */
 Hooks.on("renderSettingsConfig", (app, html, data) => {
   // Create color picker
   const settingId = "adv-reminder.customColor";

--- a/src/settings.js
+++ b/src/settings.js
@@ -10,7 +10,7 @@ Hooks.once("init", () => {
       none: "adv-reminder.DefaultButtonColor.None",
       player: "adv-reminder.DefaultButtonColor.Player",
       green: "adv-reminder.DefaultButtonColor.Green",
-      custom: "adv-reminder.DefaultButtonColor.CustomColor",
+      custom: "adv-reminder.DefaultButtonColor.Custom",
     },
     default: "none",
     onChange: (option) =>

--- a/src/settings.js
+++ b/src/settings.js
@@ -22,11 +22,14 @@ export const registerSettings = function () {
       none: "adv-reminder.DefaultButtonColor.None",
       player: "adv-reminder.DefaultButtonColor.Player",
       green: "adv-reminder.DefaultButtonColor.Green",
-      orange: "adv-reminder.DefaultButtonColor.Orange",
       custom: "adv-reminder.DefaultButtonColor.CustomColor",
     },
     default: "none",
-    onChange: setStyleVariables,
+    onChange: (option) =>
+      setStyleVariables(
+        option,
+        game.settings.get("adv-reminder", "customColor")
+      ),
   });
 
   game.settings.register("adv-reminder", "customColor", {
@@ -36,6 +39,11 @@ export const registerSettings = function () {
     config: true,
     type: String,
     default: "#000000",
+    onChange: (customColor) =>
+      setStyleVariables(
+        game.settings.get("adv-reminder", "defaultButtonColor"),
+        customColor
+      ),
   });
 };
 
@@ -44,10 +52,13 @@ export const fetchSettings = function () {
 };
 
 export const initDefaultButtonColor = function () {
-  setStyleVariables(game.settings.get("adv-reminder", "defaultButtonColor"));
+  setStyleVariables(
+    game.settings.get("adv-reminder", "defaultButtonColor"),
+    game.settings.get("adv-reminder", "customColor")
+  );
 };
 
-function setStyleVariables(option) {
+function setStyleVariables(option, customColor) {
   // set four color variables based on the option
   var varColor, varBackground, varButtonBorder, varMessageBorder;
   const setColorVars = (color) => {
@@ -73,7 +84,7 @@ function setStyleVariables(option) {
       setColorVars("#ff6400");
       break;
     case "custom":
-      // TODO
+      setColorVars(customColor);
       break;
   }
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -80,9 +80,6 @@ function setStyleVariables(option, customColor) {
     case "green":
       setColorVars("#008000");
       break;
-    case "orange":
-      setColorVars("#ff6400");
-      break;
     case "custom":
       setColorVars(customColor);
       break;

--- a/src/util.js
+++ b/src/util.js
@@ -1,10 +1,14 @@
-import { debugEnabled } from "./settings.js";
-
 export const debug = (...args) => {
-  if (debugEnabled) console.log("adv-reminder | ", ...args);
+  try {
+    const debugEnabled = game.modules
+      .get("_dev-mode")
+      ?.api?.getPackageDebugValue("adv-reminder");
+
+    if (debugEnabled) log(...args);
+  } catch (e) {}
 };
 
-export const log = (...args) => console.log("adv-reminder | ", ...args);
+export const log = (...args) => console.log("adv-reminder |", ...args);
 
 /**
  * Check if a module is active and at least a minimum version.


### PR DESCRIPTION
- By default, leaves the dialogs styled as is but gives you options to choose:
  - your player color
  - green
  - a custom color
- The settings dialog will enable/disable the custom color setting based on the first option
- The custom color also includes a color picker, similar to how you choose your player color
- Moved the debug logging flag from a hidden setting to use the Developer Mode module
- Settings file initializes itself instead of relying on the main module to call some exported functions