### PR TITLE
Grant message flag when targeted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 3.1
 - bug fix: [#40](https://github.com/kaelad02/adv-reminder/issues/40) support Inline Roll Commands and other custom enrichers in messages
 - feature: add AR Message Sample Items compendium pack
+- feature: [#38](https://github.com/kaelad02/adv-reminder/issues/38) add a grant message flag when targeted
 
 # 3.0
 

--- a/docs/message-flags.md
+++ b/docs/message-flags.md
@@ -12,6 +12,9 @@ Some of the terms used in the keys are further explained in [Terms and Abbreviat
 | flags.adv-reminder.message.attack.all | Message on all attack rolls |
 | flags.adv-reminder.message.attack.mwak/rwak/msak/rsak | Message on attacks with a specific Action Type |
 | flags.adv-reminder.message.attack.str/dex/con/int/wis/cha | Message on attacks with a specific Ability Modifier |
+| flags.adv-reminder.grants.message.attack.all | Message when targeted by all attack rolls |
+| flags.adv-reminder.grants.message.attack.mwak/rwak/msak/rsak | Message when targeted by attacks with a specific Action Type |
+| flags.adv-reminder.grants.message.attack.str/dex/con/int/wis/cha | Message when targeted by attacks with a specific Ability Modifier |
 
 ## Damage Rolls
 
@@ -20,6 +23,8 @@ Some of the terms used in the keys are further explained in [Terms and Abbreviat
 | flags.adv-reminder.message.all | Message on all rolls, including damage rolls |
 | flags.adv-reminder.message.damage.all | Message on all damage rolls |
 | flags.adv-reminder.message.damage.mwak/rwak/msak/rsak | Message on damage rolls with a specific Action Type |
+| flags.adv-reminder.grants.message.damage.all | Message when targeted by all damage rolls |
+| flags.adv-reminder.grants.message.damage.mwak/rwak/msak/rsak | Message when targeted by damage rolls with a specific Action Type |
 
 ## Ability Checks 
 

--- a/src/messages.js
+++ b/src/messages.js
@@ -143,8 +143,8 @@ export class DeathSaveMessage extends AbilityBaseMessage {
 }
 
 export class DamageMessage extends BaseMessage {
-  constructor(actor, item) {
-    super(actor);
+  constructor(actor, targetActor, item) {
+    super(actor, targetActor);
 
     /** @type {string} */
     this.actionType = item.system.actionType;
@@ -155,6 +155,14 @@ export class DamageMessage extends BaseMessage {
     return super.messageKeys.concat(
       "flags.adv-reminder.message.damage.all",
       `flags.adv-reminder.message.damage.${this.actionType}`
+    );
+  }
+
+  /** @override */
+  get targetKeys() {
+    return super.targetKeys.concat(
+      "flags.adv-reminder.grants.message.damage.all",
+      `flags.adv-reminder.grants.message.damage.${this.actionType}`
     );
   }
 }

--- a/src/messages.js
+++ b/src/messages.js
@@ -38,7 +38,7 @@ class BaseMessage {
     const targetMessages = this.targetChanges
       .filter((change) => targetKeys.includes(change.key))
       .map((change) => change.value);
-    messages.concat(...targetMessages);
+    messages.push(...targetMessages);
 
     if (messages.length > 0) {
       debug("messages found:", messages);
@@ -64,6 +64,15 @@ export class AttackMessage extends BaseMessage {
       "flags.adv-reminder.message.attack.all",
       `flags.adv-reminder.message.attack.${this.actionType}`,
       `flags.adv-reminder.message.attack.${this.abilityId}`
+    );
+  }
+
+  /** @override */
+  get targetKeys() {
+    return super.targetKeys.concat(
+      "flags.adv-reminder.grants.message.attack.all",
+      `flags.adv-reminder.grants.message.attack.${this.actionType}`,
+      `flags.adv-reminder.grants.message.attack.${this.abilityId}`
     );
   }
 }

--- a/src/messages.js
+++ b/src/messages.js
@@ -24,7 +24,7 @@ class BaseMessage {
   }
 
   get targetKeys() {
-    return ["flags.adv-reminder.grants.message.all"];
+    return undefined;
   }
 
   addMessage(options) {
@@ -35,10 +35,12 @@ class BaseMessage {
 
     // get messages from the target and merge
     const targetKeys = this.targetKeys;
-    const targetMessages = this.targetChanges
-      .filter((change) => targetKeys.includes(change.key))
-      .map((change) => change.value);
-    messages.push(...targetMessages);
+    if (targetKeys) {
+      const targetMessages = this.targetChanges
+        .filter((change) => targetKeys.includes(change.key))
+        .map((change) => change.value);
+      messages.push(...targetMessages);
+    }
 
     if (messages.length > 0) {
       debug("messages found:", messages);
@@ -69,11 +71,11 @@ export class AttackMessage extends BaseMessage {
 
   /** @override */
   get targetKeys() {
-    return super.targetKeys.concat(
+    return [
       "flags.adv-reminder.grants.message.attack.all",
       `flags.adv-reminder.grants.message.attack.${this.actionType}`,
-      `flags.adv-reminder.grants.message.attack.${this.abilityId}`
-    );
+      `flags.adv-reminder.grants.message.attack.${this.abilityId}`,
+    ];
   }
 }
 
@@ -160,9 +162,9 @@ export class DamageMessage extends BaseMessage {
 
   /** @override */
   get targetKeys() {
-    return super.targetKeys.concat(
+    return [
       "flags.adv-reminder.grants.message.damage.all",
-      `flags.adv-reminder.grants.message.damage.${this.actionType}`
-    );
+      `flags.adv-reminder.grants.message.damage.${this.actionType}`,
+    ];
   }
 }

--- a/src/module.js
+++ b/src/module.js
@@ -87,17 +87,18 @@ Hooks.on("dnd5e.preRollAttack", (item, config) => {
   debug("preRollAttack hook called");
 
   if (isFastForwarding(config)) return;
+  const target = getTarget();
 
   debug("checking for message effects on this attack roll");
-  new AttackMessage(item.actor, getTarget(), item).addMessage(config);
+  new AttackMessage(item.actor, target, item).addMessage(config);
   if (showSources) {
     debug("checking for adv/dis effects to display their source");
-    new AttackSource(item.actor, getTarget(), item).updateOptions(config);
+    new AttackSource(item.actor, target, item).updateOptions(config);
   }
 
   if (skipReminders) return;
   debug("checking for adv/dis effects on this attack roll");
-  new AttackReminder(item.actor, getTarget(), item).updateOptions(config);
+  new AttackReminder(item.actor, target, item).updateOptions(config);
 });
 
 // Saving throws
@@ -200,17 +201,18 @@ Hooks.on("dnd5e.preRollDamage", (item, config) => {
 
   // check for critical flags unless the user pressed a fast-forward key
   if (isFastForwarding(config)) return;
+  const target = getTarget();
 
   debug("checking for message effects on this damage roll");
-  new DamageMessage(item.actor, getTarget(), item).addMessage(config);
+  new DamageMessage(item.actor, target, item).addMessage(config);
   if (showSources) {
     debug("checking for adv/dis effects to display their source");
-    new CriticalSource(item.actor, getTarget(), item).updateOptions(config);
+    new CriticalSource(item.actor, target, item).updateOptions(config);
   }
 
   if (skipReminders) return;
   debug("checking for critical/normal effects on this damage roll");
-  new CriticalReminder(item.actor, getTarget(), item).updateOptions(config);
+  new CriticalReminder(item.actor, target, item).updateOptions(config);
 });
 
 // Render dialog hook

--- a/src/module.js
+++ b/src/module.js
@@ -89,7 +89,7 @@ Hooks.on("dnd5e.preRollAttack", (item, config) => {
   if (isFastForwarding(config)) return;
 
   debug("checking for message effects on this attack roll");
-  new AttackMessage(item.actor, item).addMessage(config);
+  new AttackMessage(item.actor, getTarget(), item).addMessage(config);
   if (showSources) {
     debug("checking for adv/dis effects to display their source");
     new AttackSource(item.actor, getTarget(), item).updateOptions(config);

--- a/src/module.js
+++ b/src/module.js
@@ -202,7 +202,7 @@ Hooks.on("dnd5e.preRollDamage", (item, config) => {
   if (isFastForwarding(config)) return;
 
   debug("checking for message effects on this damage roll");
-  new DamageMessage(item.actor, item).addMessage(config);
+  new DamageMessage(item.actor, getTarget(), item).addMessage(config);
   if (showSources) {
     debug("checking for adv/dis effects to display their source");
     new CriticalSource(item.actor, getTarget(), item).updateOptions(config);

--- a/test/messages.test.js
+++ b/test/messages.test.js
@@ -243,17 +243,6 @@ describe("AttackMessage message flags", () => {
 });
 
 describe("AttackMessage from target", () => {
-  test("attack with message.all flag should add the message", () => {
-    const actor = createActorWithEffects();
-    const target = createActorWithEffects(["flags.adv-reminder.grants.message.all", "message.all message"]);
-    const item = createItem("mwak", "str");
-    const options = {};
-
-    new AttackMessage(actor, target, item).addMessage(options);
-
-    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual(["message.all message"]);
-  });
-
   test("attack with message.attack.all flag should add the message", () => {
     const actor = createActorWithEffects();
     const target = createActorWithEffects([
@@ -908,17 +897,6 @@ describe("DamageMessage message flags", () => {
 });
 
 describe("DamageMessage from target", () => {
-  test("damage with message.all flag should add the message", () => {
-    const actor = createActorWithEffects();
-    const target = createActorWithEffects(["flags.adv-reminder.grants.message.all", "message.all message"]);
-    const item = createItem("mwak", "str");
-    const options = {};
-
-    new DamageMessage(actor, target, item).addMessage(options);
-
-    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual(["message.all message"]);
-  });
-
   test("damage with message.damage.all flag should add the message", () => {
     const actor = createActorWithEffects();
     const target = createActorWithEffects([

--- a/test/messages.test.js
+++ b/test/messages.test.js
@@ -118,7 +118,7 @@ describe("AttackMessage no legit active effects", () => {
     const item = createItem("mwak", "str");
     const options = {};
 
-    new AttackMessage(actor, item).addMessage(options);
+    new AttackMessage(actor, undefined, item).addMessage(options);
 
     expect(options.dialogOptions).toBeUndefined();
   });
@@ -129,7 +129,7 @@ describe("AttackMessage no legit active effects", () => {
     const item = createItem("mwak", "str");
     const options = {};
 
-    new AttackMessage(actor, item).addMessage(options);
+    new AttackMessage(actor, undefined, item).addMessage(options);
 
     expect(options.dialogOptions).toBeUndefined();
   });
@@ -140,7 +140,7 @@ describe("AttackMessage no legit active effects", () => {
     const item = createItem("mwak", "str");
     const options = {};
 
-    new AttackMessage(actor, item).addMessage(options);
+    new AttackMessage(actor, undefined, item).addMessage(options);
 
     expect(options.dialogOptions).toBeUndefined();
   });
@@ -152,7 +152,7 @@ describe("AttackMessage message flags", () => {
     const item = createItem("mwak", "str");
     const options = {};
 
-    new AttackMessage(actor, item).addMessage(options);
+    new AttackMessage(actor, undefined, item).addMessage(options);
 
     expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual(["message.all message"]);
   });
@@ -165,7 +165,7 @@ describe("AttackMessage message flags", () => {
     const item = createItem("mwak", "str");
     const options = {};
 
-    new AttackMessage(actor, item).addMessage(options);
+    new AttackMessage(actor, undefined, item).addMessage(options);
 
     expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual([
       "message.attack.all message",
@@ -180,7 +180,7 @@ describe("AttackMessage message flags", () => {
     const item = createItem("mwak", "str");
     const options = {};
 
-    new AttackMessage(actor, item).addMessage(options);
+    new AttackMessage(actor, undefined, item).addMessage(options);
 
     expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual([
       "message.attack.mwak message",
@@ -195,7 +195,7 @@ describe("AttackMessage message flags", () => {
     const item = createItem("rwak", "dex");
     const options = {};
 
-    new AttackMessage(actor, item).addMessage(options);
+    new AttackMessage(actor, undefined, item).addMessage(options);
 
     expect(options.dialogOptions).toBeUndefined();
   });
@@ -208,7 +208,7 @@ describe("AttackMessage message flags", () => {
     const item = createItem("rsak", "cha");
     const options = {};
 
-    new AttackMessage(actor, item).addMessage(options);
+    new AttackMessage(actor, undefined, item).addMessage(options);
 
     expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual([
       "message.attack.cha message",
@@ -223,7 +223,7 @@ describe("AttackMessage message flags", () => {
     const item = createItem("rsak", "int");
     const options = {};
 
-    new AttackMessage(actor, item).addMessage(options);
+    new AttackMessage(actor, undefined, item).addMessage(options);
 
     expect(options.dialogOptions).toBeUndefined();
   });
@@ -236,7 +236,7 @@ describe("AttackMessage message flags", () => {
     const item = createItem("mwak", "str");
     const options = {};
 
-    new AttackMessage(actor, item).addMessage(options);
+    new AttackMessage(actor, undefined, item).addMessage(options);
 
     expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual(["first", "second"]);
   });

--- a/test/messages.test.js
+++ b/test/messages.test.js
@@ -811,7 +811,7 @@ describe("DamageMessage no legit active effects", () => {
     const item = createItem("mwak", "str");
     const options = {};
 
-    new DamageMessage(actor, item).addMessage(options);
+    new DamageMessage(actor, undefined, item).addMessage(options);
 
     expect(options.dialogOptions).toBeUndefined();
   });
@@ -822,7 +822,7 @@ describe("DamageMessage no legit active effects", () => {
     const item = createItem("mwak", "str");
     const options = {};
 
-    new DamageMessage(actor, item).addMessage(options);
+    new DamageMessage(actor, undefined, item).addMessage(options);
 
     expect(options.dialogOptions).toBeUndefined();
   });
@@ -833,7 +833,7 @@ describe("DamageMessage no legit active effects", () => {
     const item = createItem("mwak", "str");
     const options = {};
 
-    new DamageMessage(actor, item).addMessage(options);
+    new DamageMessage(actor, undefined, item).addMessage(options);
 
     expect(options.dialogOptions).toBeUndefined();
   });
@@ -845,7 +845,7 @@ describe("DamageMessage message flags", () => {
     const item = createItem("mwak", "str");
     const options = {};
 
-    new DamageMessage(actor, item).addMessage(options);
+    new DamageMessage(actor, undefined, item).addMessage(options);
 
     expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual(["message.all message"]);
   });
@@ -858,7 +858,7 @@ describe("DamageMessage message flags", () => {
     const item = createItem("mwak", "str");
     const options = {};
 
-    new DamageMessage(actor, item).addMessage(options);
+    new DamageMessage(actor, undefined, item).addMessage(options);
 
     expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual([
       "message.damage.all message",
@@ -873,7 +873,7 @@ describe("DamageMessage message flags", () => {
     const item = createItem("mwak", "str");
     const options = {};
 
-    new DamageMessage(actor, item).addMessage(options);
+    new DamageMessage(actor, undefined, item).addMessage(options);
 
     expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual([
       "message.damage.mwak message",
@@ -888,7 +888,7 @@ describe("DamageMessage message flags", () => {
     const item = createItem("rwak", "dex");
     const options = {};
 
-    new DamageMessage(actor, item).addMessage(options);
+    new DamageMessage(actor, undefined, item).addMessage(options);
 
     expect(options.dialogOptions).toBeUndefined();
   });
@@ -901,7 +901,80 @@ describe("DamageMessage message flags", () => {
     const item = createItem("mwak", "str");
     const options = {};
 
-    new DamageMessage(actor, item).addMessage(options);
+    new DamageMessage(actor, undefined, item).addMessage(options);
+
+    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual(["first", "second"]);
+  });
+});
+
+describe("DamageMessage from target", () => {
+  test("damage with message.all flag should add the message", () => {
+    const actor = createActorWithEffects();
+    const target = createActorWithEffects(["flags.adv-reminder.grants.message.all", "message.all message"]);
+    const item = createItem("mwak", "str");
+    const options = {};
+
+    new DamageMessage(actor, target, item).addMessage(options);
+
+    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual(["message.all message"]);
+  });
+
+  test("damage with message.damage.all flag should add the message", () => {
+    const actor = createActorWithEffects();
+    const target = createActorWithEffects([
+      "flags.adv-reminder.grants.message.damage.all",
+      "message.damage.all message",
+    ]);
+    const item = createItem("mwak", "str");
+    const options = {};
+
+    new DamageMessage(actor, target, item).addMessage(options);
+
+    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual([
+      "message.damage.all message",
+    ]);
+  });
+
+  test("damage with message.damage.mwak flag should add the message for Melee Weapon damage", () => {
+    const actor = createActorWithEffects();
+    const target = createActorWithEffects([
+      "flags.adv-reminder.grants.message.damage.mwak",
+      "message.damage.mwak message",
+    ]);
+    const item = createItem("mwak", "str");
+    const options = {};
+
+    new DamageMessage(actor, target, item).addMessage(options);
+
+    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual([
+      "message.damage.mwak message",
+    ]);
+  });
+
+  test("damage with message.damage.mwak flag should not add the message for Ranged Weapon damage", () => {
+    const actor = createActorWithEffects();
+    const target = createActorWithEffects([
+      "flags.adv-reminder.grants.message.damage.mwak",
+      "message.damage.mwak message",
+    ]);
+    const item = createItem("rwak", "dex");
+    const options = {};
+
+    new DamageMessage(actor, target, item).addMessage(options);
+
+    expect(options.dialogOptions).toBeUndefined();
+  });
+
+  test("damage with two messages should add both messages", () => {
+    const actor = createActorWithEffects(["flags.adv-reminder.message.damage.all", "first"]);
+    const target = createActorWithEffects([
+      "flags.adv-reminder.grants.message.damage.mwak",
+      "second",
+    ]);
+    const item = createItem("mwak", "str");
+    const options = {};
+
+    new DamageMessage(actor, target, item).addMessage(options);
 
     expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual(["first", "second"]);
   });

--- a/test/messages.test.js
+++ b/test/messages.test.js
@@ -242,6 +242,109 @@ describe("AttackMessage message flags", () => {
   });
 });
 
+describe("AttackMessage from target", () => {
+  test("attack with message.all flag should add the message", () => {
+    const actor = createActorWithEffects();
+    const target = createActorWithEffects(["flags.adv-reminder.grants.message.all", "message.all message"]);
+    const item = createItem("mwak", "str");
+    const options = {};
+
+    new AttackMessage(actor, target, item).addMessage(options);
+
+    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual(["message.all message"]);
+  });
+
+  test("attack with message.attack.all flag should add the message", () => {
+    const actor = createActorWithEffects();
+    const target = createActorWithEffects([
+      "flags.adv-reminder.grants.message.attack.all",
+      "message.attack.all message",
+    ]);
+    const item = createItem("mwak", "str");
+    const options = {};
+
+    new AttackMessage(actor, target, item).addMessage(options);
+
+    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual([
+      "message.attack.all message",
+    ]);
+  });
+
+  test("attack with message.attack.mwak flag should add the message for Melee Weapon Attack", () => {
+    const actor = createActorWithEffects();
+    const target = createActorWithEffects([
+      "flags.adv-reminder.grants.message.attack.mwak",
+      "message.attack.mwak message",
+    ]);
+    const item = createItem("mwak", "str");
+    const options = {};
+
+    new AttackMessage(actor, target, item).addMessage(options);
+
+    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual([
+      "message.attack.mwak message",
+    ]);
+  });
+
+  test("attack with message.attack.mwak flag should not add the message for Ranged Weapon Attack", () => {
+    const actor = createActorWithEffects();
+    const target = createActorWithEffects([
+      "flags.adv-reminder.grants.message.attack.mwak",
+      "message.attack.mwak message",
+    ]);
+    const item = createItem("rwak", "dex");
+    const options = {};
+
+    new AttackMessage(actor, target, item).addMessage(options);
+
+    expect(options.dialogOptions).toBeUndefined();
+  });
+
+  test("attack with message.attack.cha flag should add the message for Charisma Attack", () => {
+    const actor = createActorWithEffects();
+    const target = createActorWithEffects([
+      "flags.adv-reminder.grants.message.attack.cha",
+      "message.attack.cha message",
+    ]);
+    const item = createItem("rsak", "cha");
+    const options = {};
+
+    new AttackMessage(actor, target, item).addMessage(options);
+
+    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual([
+      "message.attack.cha message",
+    ]);
+  });
+
+  test("attack with message.attack.cha flag should not add the message for Intelligence Attack", () => {
+    const actor = createActorWithEffects();
+    const target = createActorWithEffects([
+      "flags.adv-reminder.grants.message.attack.cha",
+      "message.attack.cha",
+    ]);
+    const item = createItem("rsak", "int");
+    const options = {};
+
+    new AttackMessage(actor, target, item).addMessage(options);
+
+    expect(options.dialogOptions).toBeUndefined();
+  });
+
+  test("attack with two messages should add both messages", () => {
+    const actor = createActorWithEffects(["flags.adv-reminder.message.attack.all", "first"]);
+    const target = createActorWithEffects([
+      "flags.adv-reminder.grants.message.attack.mwak",
+      "second",
+    ]);
+    const item = createItem("mwak", "str");
+    const options = {};
+
+    new AttackMessage(actor, target, item).addMessage(options);
+
+    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual(["first", "second"]);
+  });
+});
+
 describe("AbilityCheckMessage no legit active effects", () => {
   test("ability check with no active effects should not add a message", () => {
     const actor = createActorWithEffects();


### PR DESCRIPTION
Add a "grants.message" flag to show messages when targeted by attacks. Included on both attack and damage rolls.