### PR TITLE
Add better support for Ready Set Roll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 3.2.0
 
+- feature: add better support for Ready Set Roll with adv/dis checks
 - feature: apply Midi's flags to the actor instead of reading the active effects directly
 - bug fix: disadvantage on stealth from armor not working consistently
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 3.2.0
 
-- feature: add better support for Ready Set Roll with adv/dis checks
+- feature: add better support for Ready Set Roll with adv/dis/crit checks
 - feature: apply Midi's flags to the actor instead of reading the active effects directly
 - bug fix: disadvantage on stealth from armor not working consistently
 

--- a/README.md
+++ b/README.md
@@ -56,5 +56,5 @@ Notes about other modules.
 [Ready Set Roll for D&D5e](https://foundryvtt.com/packages/ready-set-roll-5e) This module works with Ready Set Roll with the following notes:
 
 - This module will apply advantage/disadvantage on checks even if RSR is configured for quick rolls. This is skipped if you hold down one of the roll modifier keys to manually apply advantage/disadvantage (similar to core behavior). 
-- This module doesn't check for critical on damage rolls, yet. With it enabled it causes a bug so that check is disabled for now.
-- Does not show messages if RSR is configured for quick rolls since there is no dialog to show them.
+- Effects for critical hits work but not those that cancel crits because of how early this module has to set the `isCrit` flag
+- Does not show messages if RSR is configured for quick rolls since there is no dialog to show them

--- a/README.md
+++ b/README.md
@@ -47,10 +47,14 @@ Notes about other modules.
 [Midi QOL](https://foundryvtt.com/packages/midi-qol) This module works with Midi QOL, however there is a lot of crossover. Both modules can handle the advantage/disadvantage/critical flags, so you don't need this module for that. If you want the CSS change and messages feature, then it works with the following notes:
 
 - This module will not process the advantage/disadvantage/critical flags if Midi QOL is active, since it will process them already
-- Does not show messages if Midi QOL is configured to fast forward rolls
+- Does not show messages if Midi QOL is configured to fast forward rolls since there is no dialog to show them 
 
 [Faster Rolling by Default DnD5e](https://foundryvtt.com/packages/faster-rolling-by-default-5e) This moodule works with Faster Rolling by Default. If the dialog is shown, it will show any messages and have the default button set correctly.
 
 [Roll Groups](https://foundryvtt.com/packages/rollgroups) This module works with Roll Groups.
 
-[Ready Set Roll for D&D5e](https://foundryvtt.com/packages/ready-set-roll-5e) This module works with Ready Set Roll but does nothing when quick rolls are enabled. Since quick rolls fast forward, skipping the dialog, this module does nothing. However, if you have quick rolls disabled for certain rolls then it will work, processing advantage/disadvantage/critical defaults and showing messages.
+[Ready Set Roll for D&D5e](https://foundryvtt.com/packages/ready-set-roll-5e) This module works with Ready Set Roll with the following notes:
+
+- This module will apply advantage/disadvantage on checks even if RSR is configured for quick rolls. This is skipped if you hold down one of the roll modifier keys to manually apply advantage/disadvantage (similar to core behavior). 
+- This module doesn't check for critical on damage rolls, yet. With it enabled it causes a bug so that check is disabled for now.
+- Does not show messages if RSR is configured for quick rolls since there is no dialog to show them.

--- a/src/fails.js
+++ b/src/fails.js
@@ -8,7 +8,7 @@ class BaseFail {
 
   /**
    * Get the midi-qol flags on the actor, flattened.
-   * @param {Actor5e} actor 
+   * @param {Actor5e} actor
    * @returns {object} the midi-qol flags on the actor, flattened
    */
   _getFlags(actor) {
@@ -26,6 +26,8 @@ class BaseFail {
    * @returns true if the roll should fail, false if it may continue
    */
   fails(options) {
+    debug("checking for fail flags for the roll");
+
     // get the active effect keys that will fail
     const failKeys = this.failKeys;
     debug("failKeys", failKeys);
@@ -41,9 +43,7 @@ class BaseFail {
 
   async toMessage(messageData) {
     // content that immatates a die roll
-    const content = await renderTemplate(
-      "modules/adv-reminder/templates/fail-dice-roll.hbs"
-    );
+    const content = await renderTemplate("modules/adv-reminder/templates/fail-dice-roll.hbs");
     // merge basic data with child's data
     const chatData = foundry.utils.mergeObject(
       {

--- a/src/messages.js
+++ b/src/messages.js
@@ -28,6 +28,8 @@ class BaseMessage {
   }
 
   addMessage(options) {
+    debug("checking for message effects");
+
     const keys = this.messageKeys;
     const messages = this.changes
       .filter((change) => keys.includes(change.key))

--- a/src/module.js
+++ b/src/module.js
@@ -1,49 +1,21 @@
-import { AbilitySaveFail } from "./fails.js";
-import {
-  AbilityCheckMessage,
-  AbilitySaveMessage,
-  AttackMessage,
-  DamageMessage,
-  DeathSaveMessage,
-  SkillMessage,
-} from "./messages.js";
-import {
-  AttackReminder,
-  AbilityCheckReminder,
-  AbilitySaveReminder,
-  CriticalReminder,
-  DeathSaveReminder,
-  SkillReminder,
-} from "./reminders.js";
+import CoreRollerHooks from "./rollers/core.js";
+import MidiRollerHooks from "./rollers/midi.js";
 import SamplePackBuilder from "./sample-pack.js";
-import { showSources } from "./settings.js";
-import {
-  AbilityCheckSource,
-  AbilitySaveSource,
-  AttackSource,
-  CriticalSource,
-  DeathSaveSource,
-  SkillSource,
-} from "./sources.js";
 import { debug, debugEnabled, log } from "./util.js";
 
 const CIRCLE_INFO = `<i class="fa-solid fa-circle-info"></i> `;
-let checkArmorStealth;
-let skipReminders;
 
 Hooks.once("init", () => {
   log("initializing Advantage Reminder");
 
-  // DAE version 0.8.81 added support for "impose stealth disadvantage"
-  checkArmorStealth = !game.modules.get("dae")?.active;
-  debug("checkArmorStealth", checkArmorStealth);
+  // initialize the roller hooks helper class
+  let rollerHooks;
+  if (game.modules.get("midi-qol")?.active) rollerHooks = new MidiRollerHooks();
+  else rollerHooks = new CoreRollerHooks();
+  rollerHooks.init();
 
-  // skip all reminder checks if Midi is active since it will do it anyways
-  const midiActive = game.modules.get("midi-qol")?.active;
-  skipReminders = midiActive;
-  debug("skipReminders", skipReminders);
-
-  if (!midiActive) Hooks.on("applyActiveEffect", applyMidiCustom);
+  // register hook to apply Midi's flags
+  if (rollerHooks.shouldApplyMidiActiveEffect()) Hooks.on("applyActiveEffect", applyMidiCustom);
 });
 
 // Apply Midi-QOL's custom active effects
@@ -102,141 +74,6 @@ Hooks.once("DAE.setupComplete", () => {
 Hooks.once("ready", () => {
   // expose SamplePackBuilder
   if (debugEnabled) window.samplePack = new SamplePackBuilder();
-});
-
-// Attack rolls
-Hooks.on("dnd5e.preRollAttack", (item, config) => {
-  debug("preRollAttack hook called");
-
-  if (isFastForwarding(config)) return;
-  const target = getTarget();
-
-  debug("checking for message effects on this attack roll");
-  new AttackMessage(item.actor, target, item).addMessage(config);
-  if (showSources) {
-    debug("checking for adv/dis effects to display their source");
-    new AttackSource(item.actor, target, item).updateOptions(config);
-  }
-
-  if (skipReminders) return;
-  debug("checking for adv/dis effects on this attack roll");
-  new AttackReminder(item.actor, target, item).updateOptions(config);
-});
-
-// Saving throws
-Hooks.on("dnd5e.preRollAbilitySave", (actor, config, abilityId) => {
-  debug("preRollAbilitySave hook called");
-
-  // check if an effect says to fail this roll
-  if (!skipReminders) {
-    const failChecker = new AbilitySaveFail(actor, abilityId);
-    if (failChecker.fails(config)) return false;
-  }
-
-  if (isFastForwarding(config)) return;
-
-  debug("checking for message effects on this saving throw");
-  new AbilitySaveMessage(actor, abilityId).addMessage(config);
-  if (showSources) {
-    debug("checking for adv/dis effects to display their source");
-    new AbilitySaveSource(actor, abilityId).updateOptions(config);
-  }
-
-  if (skipReminders) return;
-  debug("checking for adv/dis effects on this saving throw");
-  new AbilitySaveReminder(actor, abilityId).updateOptions(config);
-});
-
-// Ability checks
-Hooks.on("dnd5e.preRollAbilityTest", (actor, config, abilityId) => {
-  debug("preRollAbilityTest hook called");
-
-  if (isFastForwarding(config)) return;
-
-  debug("checking for message effects on this ability check");
-  new AbilityCheckMessage(actor, abilityId).addMessage(config);
-  if (showSources) {
-    debug("checking for adv/dis effects to display their source");
-    new AbilityCheckSource(actor, abilityId).updateOptions(config);
-  }
-
-  if (skipReminders) return;
-  debug("checking for adv/dis effects on this ability check");
-  new AbilityCheckReminder(actor, abilityId).updateOptions(config);
-});
-
-// Skill checks
-Hooks.on("dnd5e.preRollSkill", (actor, config, skillId) => {
-  debug("preRollSkill hook called");
-
-  if (isFastForwarding(config)) return;
-
-  debug("checking for message effects on this skill check");
-  new SkillMessage(actor, skillId).addMessage(config);
-  if (showSources) {
-    debug("checking for adv/dis effects to display their source");
-    new SkillSource(actor, skillId, true).updateOptions(config);
-  }
-
-  if (skipReminders) return;
-  debug("checking for adv/dis effects on this skill check");
-  new SkillReminder(actor, skillId, checkArmorStealth).updateOptions(config);
-});
-
-// Tool checks
-Hooks.on("dnd5e.preRollToolCheck", (item, config) => {
-  debug("preRollToolCheck hook called");
-
-  if (isFastForwarding(config)) return;
-
-  debug("checking for message effects on this tool check");
-  new AbilityCheckMessage(item.actor, item.system.ability).addMessage(config);
-  if (showSources) {
-    debug("checking for adv/dis effects to display their source");
-    new AbilityCheckSource(item.actor, item.system.ability).updateOptions(config);
-  }
-
-  if (skipReminders) return;
-  debug("checking for adv/dis effects on this tool check");
-  new AbilityCheckReminder(item.actor, item.system.ability).updateOptions(config);
-});
-
-// Death saves
-Hooks.on("dnd5e.preRollDeathSave", (actor, config) => {
-  debug("preRollDeathSave hook called");
-
-  if (isFastForwarding(config)) return;
-
-  debug("checking for message effects on this death save");
-  new DeathSaveMessage(actor).addMessage(config);
-  if (showSources) {
-    debug("checking for adv/dis effects to display their source");
-    new DeathSaveSource(actor).updateOptions(config);
-  }
-
-  if (skipReminders) return;
-  debug("checking for adv/dis effects on this death save");
-  new DeathSaveReminder(actor).updateOptions(config);
-});
-
-// Damage rolls
-Hooks.on("dnd5e.preRollDamage", (item, config) => {
-  debug("preRollDamage hook called");
-
-  // check for critical flags unless the user pressed a fast-forward key
-  if (isFastForwarding(config)) return;
-  const target = getTarget();
-
-  debug("checking for message effects on this damage roll");
-  new DamageMessage(item.actor, target, item).addMessage(config);
-  if (showSources) {
-    debug("checking for adv/dis effects to display their source");
-    new CriticalSource(item.actor, target, item).updateOptions(config);
-  }
-
-  if (skipReminders) return;
-  debug("checking for critical/normal effects on this damage roll");
-  new CriticalReminder(item.actor, target, item).updateOptions(config);
 });
 
 // Render dialog hook
@@ -308,32 +145,4 @@ async function prepareMessage(dialogOptions) {
     debug("messages", messages, "enriched", enriched);
     return enriched;
   }
-}
-
-/**
- * Check if we should fast-forward the roll by checking the fastForward flag
- * and if one of the modifier keys was pressed.
- * @param {object} options
- * @param {boolean} [options.fastForward] a specific fastForward flag
- * @param {Event} [options.event] the triggering event
- * @returns {boolean} true if they are fast-forwarding, false otherwise
- */
-function isFastForwarding({ fastForward = false, event = {} }) {
-  const isFF = !!(
-    fastForward ||
-    event?.shiftKey ||
-    event?.altKey ||
-    event?.ctrlKey ||
-    event?.metaKey
-  );
-  if (isFF) debug("fast-forwarding the roll, stop processing");
-  return isFF;
-}
-
-/**
- * Get the first targeted actor, if there are any targets at all.
- * @returns {Actor5e} the first target, if there are any
- */
-function getTarget() {
-  return [...game.user.targets][0]?.actor;
 }

--- a/src/module.js
+++ b/src/module.js
@@ -1,5 +1,6 @@
 import CoreRollerHooks from "./rollers/core.js";
 import MidiRollerHooks from "./rollers/midi.js";
+import ReadySetRollHooks from "./rollers/rsr.js";
 import SamplePackBuilder from "./sample-pack.js";
 import { debug, debugEnabled, log } from "./util.js";
 
@@ -11,6 +12,7 @@ Hooks.once("init", () => {
   // initialize the roller hooks helper class
   let rollerHooks;
   if (game.modules.get("midi-qol")?.active) rollerHooks = new MidiRollerHooks();
+  else if (game.modules.get("ready-set-roll-5e")?.active) rollerHooks = new ReadySetRollHooks();
   else rollerHooks = new CoreRollerHooks();
   rollerHooks.init();
 

--- a/src/reminders.js
+++ b/src/reminders.js
@@ -8,12 +8,16 @@ class BaseReminder {
 
   /**
    * Get the midi-qol flags on the actor, flattened.
-   * @param {Actor5e*} actor 
+   * @param {Actor5e*} actor
    * @returns {object} the midi-qol flags on the actor, flattened
    */
   _getFlags(actor) {
     const midiFlags = actor?.flags["midi-qol"] || {};
     return flattenObject(midiFlags);
+  }
+
+  _message() {
+    debug("checking for adv/dis effects for the roll");
   }
 
   /**
@@ -32,9 +36,7 @@ class BaseReminder {
         if (label) disadvantage = true;
       },
       update: (options) => {
-        debug(
-          `updating options with {advantage: ${advantage}, disadvantage: ${disadvantage}}`
-        );
+        debug(`updating options with {advantage: ${advantage}, disadvantage: ${disadvantage}}`);
         // only set if adv or dis, the die roller doesn't handle when both are true correctly
         if (advantage && !disadvantage) options.advantage = true;
         else if (!advantage && disadvantage) options.disadvantage = true;
@@ -56,6 +58,8 @@ export class AttackReminder extends BaseReminder {
   }
 
   updateOptions(options) {
+    this._message();
+
     // quick return if there are no flags
     if (this.actorFlags === {} && this.targetFlags === {}) return;
 
@@ -106,6 +110,8 @@ class AbilityBaseReminder extends BaseReminder {
   }
 
   updateOptions(options) {
+    this._message();
+
     // quick return if there are no flags
     if (this.actorFlags === {}) return;
 
@@ -171,10 +177,7 @@ export class SkillReminder extends AbilityCheckReminder {
 
   /** @override */
   get advantageKeys() {
-    return super.advantageKeys.concat([
-      "advantage.skill.all",
-      `advantage.skill.${this.skillId}`,
-    ]);
+    return super.advantageKeys.concat(["advantage.skill.all", `advantage.skill.${this.skillId}`]);
   }
 
   /** @override */
@@ -187,6 +190,8 @@ export class SkillReminder extends AbilityCheckReminder {
 
   /** @override */
   updateOptions(options) {
+    this._message();
+
     // get the active effect keys applicable for this roll
     const advKeys = this.advantageKeys;
     const disKeys = this.disadvantageKeys;
@@ -208,10 +213,7 @@ export class SkillReminder extends AbilityCheckReminder {
   _armorStealthDisadvantage() {
     if (this.skillId === "ste") {
       const item = this.items.find(
-        (item) =>
-          item.type === "equipment" &&
-          item.system?.equipped &&
-          item.system?.stealth
+        (item) => item.type === "equipment" && item.system?.equipped && item.system?.stealth
       );
       debug("equiped item that imposes stealth disadvantage", item?.name);
       return item?.name;
@@ -226,10 +228,7 @@ export class DeathSaveReminder extends AbilityBaseReminder {
 
   /** @override */
   get advantageKeys() {
-    return super.advantageKeys.concat([
-      "advantage.ability.save.all",
-      "advantage.deathSave",
-    ]);
+    return super.advantageKeys.concat(["advantage.ability.save.all", "advantage.deathSave"]);
   }
 
   /** @override */
@@ -252,26 +251,16 @@ export class CriticalReminder extends BaseReminder {
   }
 
   updateOptions(options) {
+    this._message();
+
     // quick return if there are no flags
     if (this.actorFlags === {} && this.targetFlags === {}) return;
 
     // build the active effect keys applicable for this roll
-    const critKeys = [
-      "critical.all",
-      `critical.${this.actionType}`,
-    ];
-    const normalKeys = [
-      "noCritical.all",
-      `noCritical.${this.actionType}`,
-    ];
-    const grantsCritKeys = [
-      "grants.critical.all",
-      `grants.critical.${this.actionType}`,
-    ];
-    const grantsNormalKeys = [
-      "fail.critical.all",
-      `fail.critical.${this.actionType}`,
-    ];
+    const critKeys = ["critical.all", `critical.${this.actionType}`];
+    const normalKeys = ["noCritical.all", `noCritical.${this.actionType}`];
+    const grantsCritKeys = ["grants.critical.all", `grants.critical.${this.actionType}`];
+    const grantsNormalKeys = ["fail.critical.all", `fail.critical.${this.actionType}`];
 
     // find matching keys and update options
     const accumulator = this._accumulator();

--- a/src/reminders.js
+++ b/src/reminders.js
@@ -250,7 +250,7 @@ export class CriticalReminder extends BaseReminder {
     this.actionType = item.system.actionType;
   }
 
-  updateOptions(options) {
+  updateOptions(options, critProp = "critical") {
     this._message();
 
     // quick return if there are no flags
@@ -266,7 +266,7 @@ export class CriticalReminder extends BaseReminder {
     const accumulator = this._accumulator();
     accumulator.add(this.actorFlags, critKeys, normalKeys);
     accumulator.add(this.targetFlags, grantsCritKeys, grantsNormalKeys);
-    accumulator.update(options);
+    accumulator.update(options, critProp);
   }
 
   /** @override */
@@ -279,11 +279,11 @@ export class CriticalReminder extends BaseReminder {
         crit = critKeys.reduce((accum, curr) => accum || actorFlags[curr], crit);
         normal = normalKeys.reduce((accum, curr) => accum || actorFlags[curr], normal);
       },
-      update: (options) => {
+      update: (options, critProp) => {
         // a normal hit overrides a crit
         const critical = normal ? false : !!crit;
-        debug(`updating critical: ${critical}`);
-        options.critical = critical;
+        debug(`updating ${critProp}: ${critical}`);
+        options[critProp] = critical;
       },
     };
   }

--- a/src/rollers/core.js
+++ b/src/rollers/core.js
@@ -1,0 +1,191 @@
+import { AbilitySaveFail } from "../fails.js";
+import {
+  AbilityCheckMessage,
+  AbilitySaveMessage,
+  AttackMessage,
+  DamageMessage,
+  DeathSaveMessage,
+  SkillMessage,
+} from "../messages.js";
+import {
+  AttackReminder,
+  AbilityCheckReminder,
+  AbilitySaveReminder,
+  CriticalReminder,
+  DeathSaveReminder,
+  SkillReminder,
+} from "../reminders.js";
+import { showSources } from "../settings.js";
+import {
+  AbilityCheckSource,
+  AbilitySaveSource,
+  AttackSource,
+  CriticalSource,
+  DeathSaveSource,
+  SkillSource,
+} from "../sources.js";
+import { debug, getTarget } from "../util.js";
+
+// the core behavior, no other roller modules
+// meant for setting up and defining the "dnd5e.pre???" hooks
+
+export default class CoreRollHooks {
+  // setup everything specific to the roller
+  init() {
+    // TODO should we get checkArmorStealth here or pass in via constructor?
+
+    // register all the dnd5e.pre hooks
+    Hooks.on("dnd5e.preRollAttack", this.preRollAttack);
+    Hooks.on("dnd5e.preRollAbilitySave", this.preRollAbilitySave);
+    Hooks.on("dnd5e.preRollAbilityTest", this.preRollAbilityTest);
+    Hooks.on("dnd5e.preRollSkill", this.preRollSkill);
+    Hooks.on("dnd5e.preRollToolCheck", this.preRollToolCheck);
+    Hooks.on("dnd5e.preRollDeathSave", this.preRollDeathSave);
+    Hooks.on("dnd5e.preRollDamage", this.preRollDamage);
+  }
+
+  // applying Midi flags should be done outside this class,
+  // but we'll ask whether to do it or not here
+  shouldApplyMidiActiveEffect() {
+    return true;
+  }
+
+  preRollAttack(item, config) {
+    debug("preRollAttack hook called");
+
+    if (this.isFastForwarding(config)) return;
+    const target = getTarget();
+
+    debug("checking for message effects on this attack roll");
+    new AttackMessage(item.actor, target, item).addMessage(config);
+    if (showSources) {
+      debug("checking for adv/dis effects to display their source");
+      new AttackSource(item.actor, target, item).updateOptions(config);
+    }
+
+    debug("checking for adv/dis effects on this attack roll");
+    new AttackReminder(item.actor, target, item).updateOptions(config);
+  }
+
+  preRollAbilitySave(actor, config, abilityId) {
+    debug("preRollAbilitySave hook called");
+
+    // check if an effect says to fail this roll
+    const failChecker = new AbilitySaveFail(actor, abilityId);
+    if (failChecker.fails(config)) return false;
+
+    if (this.isFastForwarding(config)) return;
+
+    debug("checking for message effects on this saving throw");
+    new AbilitySaveMessage(actor, abilityId).addMessage(config);
+    if (showSources) {
+      debug("checking for adv/dis effects to display their source");
+      new AbilitySaveSource(actor, abilityId).updateOptions(config);
+    }
+
+    debug("checking for adv/dis effects on this saving throw");
+    new AbilitySaveReminder(actor, abilityId).updateOptions(config);
+  }
+
+  preRollAbilityTest(actor, config, abilityId) {
+    debug("preRollAbilityTest hook called");
+
+    if (this.isFastForwarding(config)) return;
+
+    debug("checking for message effects on this ability check");
+    new AbilityCheckMessage(actor, abilityId).addMessage(config);
+    if (showSources) {
+      debug("checking for adv/dis effects to display their source");
+      new AbilityCheckSource(actor, abilityId).updateOptions(config);
+    }
+
+    debug("checking for adv/dis effects on this ability check");
+    new AbilityCheckReminder(actor, abilityId).updateOptions(config);
+  }
+
+  preRollSkill(actor, config, skillId) {
+    debug("preRollSkill hook called");
+
+    if (this.isFastForwarding(config)) return;
+
+    debug("checking for message effects on this skill check");
+    new SkillMessage(actor, skillId).addMessage(config);
+    if (showSources) {
+      debug("checking for adv/dis effects to display their source");
+      new SkillSource(actor, skillId, true).updateOptions(config);
+    }
+
+    debug("checking for adv/dis effects on this skill check");
+    new SkillReminder(actor, skillId, checkArmorStealth).updateOptions(config);
+  }
+
+  preRollToolCheck(item, config) {
+    debug("preRollToolCheck hook called");
+
+    if (this.isFastForwarding(config)) return;
+
+    debug("checking for message effects on this tool check");
+    new AbilityCheckMessage(item.actor, item.system.ability).addMessage(config);
+    if (showSources) {
+      debug("checking for adv/dis effects to display their source");
+      new AbilityCheckSource(item.actor, item.system.ability).updateOptions(config);
+    }
+
+    debug("checking for adv/dis effects on this tool check");
+    new AbilityCheckReminder(item.actor, item.system.ability).updateOptions(config);
+  }
+
+  preRollDeathSave(actor, config) {
+    debug("preRollDeathSave hook called");
+
+    if (this.isFastForwarding(config)) return;
+
+    debug("checking for message effects on this death save");
+    new DeathSaveMessage(actor).addMessage(config);
+    if (showSources) {
+      debug("checking for adv/dis effects to display their source");
+      new DeathSaveSource(actor).updateOptions(config);
+    }
+
+    debug("checking for adv/dis effects on this death save");
+    new DeathSaveReminder(actor).updateOptions(config);
+  }
+
+  preRollDamage(item, config) {
+    debug("preRollDamage hook called");
+
+    // check for critical flags unless the user pressed a fast-forward key
+    if (this.isFastForwarding(config)) return;
+    const target = getTarget();
+
+    debug("checking for message effects on this damage roll");
+    new DamageMessage(item.actor, target, item).addMessage(config);
+    if (showSources) {
+      debug("checking for adv/dis effects to display their source");
+      new CriticalSource(item.actor, target, item).updateOptions(config);
+    }
+
+    debug("checking for critical/normal effects on this damage roll");
+    new CriticalReminder(item.actor, target, item).updateOptions(config);
+  }
+
+  /**
+   * Check if we should fast-forward the roll by checking the fastForward flag
+   * and if one of the modifier keys was pressed.
+   * @param {object} options
+   * @param {boolean} [options.fastForward] a specific fastForward flag
+   * @param {Event} [options.event] the triggering event
+   * @returns {boolean} true if they are fast-forwarding, false otherwise
+   */
+  isFastForwarding({ fastForward = false, event = {} }) {
+    const isFF = !!(
+      fastForward ||
+      event?.shiftKey ||
+      event?.altKey ||
+      event?.ctrlKey ||
+      event?.metaKey
+    );
+    if (isFF) debug("fast-forwarding the roll, stop processing");
+    return isFF;
+  }
+}

--- a/src/rollers/core.js
+++ b/src/rollers/core.js
@@ -30,9 +30,17 @@ import { debug, getTarget } from "../util.js";
 // meant for setting up and defining the "dnd5e.pre???" hooks
 
 export default class CoreRollHooks {
+  /**
+   * If true, check armor for stealth checks.
+   * @type {boolean}
+   */
+  checkArmorStealth;
+
   // setup everything specific to the roller
   init() {
-    // TODO should we get checkArmorStealth here or pass in via constructor?
+    // DAE version 0.8.81 added support for "impose stealth disadvantage"
+    this.checkArmorStealth = !game.modules.get("dae")?.active;
+    debug("checkArmorStealth", this.checkArmorStealth);
 
     // register all the dnd5e.pre hooks
     Hooks.on("dnd5e.preRollAttack", this.preRollAttack);
@@ -116,7 +124,7 @@ export default class CoreRollHooks {
     }
 
     debug("checking for adv/dis effects on this skill check");
-    new SkillReminder(actor, skillId, checkArmorStealth).updateOptions(config);
+    new SkillReminder(actor, skillId, this.checkArmorStealth).updateOptions(config);
   }
 
   preRollToolCheck(item, config) {

--- a/src/rollers/core.js
+++ b/src/rollers/core.js
@@ -43,13 +43,13 @@ export default class CoreRollerHooks {
     debug("checkArmorStealth", this.checkArmorStealth);
 
     // register all the dnd5e.pre hooks
-    Hooks.on("dnd5e.preRollAttack", this.preRollAttack);
-    Hooks.on("dnd5e.preRollAbilitySave", this.preRollAbilitySave);
-    Hooks.on("dnd5e.preRollAbilityTest", this.preRollAbilityTest);
-    Hooks.on("dnd5e.preRollSkill", this.preRollSkill);
-    Hooks.on("dnd5e.preRollToolCheck", this.preRollToolCheck);
-    Hooks.on("dnd5e.preRollDeathSave", this.preRollDeathSave);
-    Hooks.on("dnd5e.preRollDamage", this.preRollDamage);
+    Hooks.on("dnd5e.preRollAttack", this.preRollAttack.bind(this));
+    Hooks.on("dnd5e.preRollAbilitySave", this.preRollAbilitySave.bind(this));
+    Hooks.on("dnd5e.preRollAbilityTest", this.preRollAbilityTest.bind(this));
+    Hooks.on("dnd5e.preRollSkill", this.preRollSkill.bind(this));
+    Hooks.on("dnd5e.preRollToolCheck", this.preRollToolCheck.bind(this));
+    Hooks.on("dnd5e.preRollDeathSave", this.preRollDeathSave.bind(this));
+    Hooks.on("dnd5e.preRollDamage", this.preRollDamage.bind(this));
   }
 
   // applying Midi flags should be done outside this class,

--- a/src/rollers/core.js
+++ b/src/rollers/core.js
@@ -68,34 +68,21 @@ export default class CoreRollerHooks {
     if (this.isFastForwarding(config)) return;
     const target = getTarget();
 
-    debug("checking for message effects on this attack roll");
     new AttackMessage(item.actor, target, item).addMessage(config);
-    if (showSources) {
-      debug("checking for adv/dis effects to display their source");
-      new AttackSource(item.actor, target, item).updateOptions(config);
-    }
-
-    debug("checking for adv/dis effects on this attack roll");
+    if (showSources) new AttackSource(item.actor, target, item).updateOptions(config);
     new AttackReminder(item.actor, target, item).updateOptions(config);
   }
 
   preRollAbilitySave(actor, config, abilityId) {
     debug("preRollAbilitySave hook called");
 
-    // check if an effect says to fail this roll
     const failChecker = new AbilitySaveFail(actor, abilityId);
     if (failChecker.fails(config)) return false;
 
     if (this.isFastForwarding(config)) return;
 
-    debug("checking for message effects on this saving throw");
     new AbilitySaveMessage(actor, abilityId).addMessage(config);
-    if (showSources) {
-      debug("checking for adv/dis effects to display their source");
-      new AbilitySaveSource(actor, abilityId).updateOptions(config);
-    }
-
-    debug("checking for adv/dis effects on this saving throw");
+    if (showSources) new AbilitySaveSource(actor, abilityId).updateOptions(config);
     new AbilitySaveReminder(actor, abilityId).updateOptions(config);
   }
 
@@ -104,14 +91,8 @@ export default class CoreRollerHooks {
 
     if (this.isFastForwarding(config)) return;
 
-    debug("checking for message effects on this ability check");
     new AbilityCheckMessage(actor, abilityId).addMessage(config);
-    if (showSources) {
-      debug("checking for adv/dis effects to display their source");
-      new AbilityCheckSource(actor, abilityId).updateOptions(config);
-    }
-
-    debug("checking for adv/dis effects on this ability check");
+    if (showSources) new AbilityCheckSource(actor, abilityId).updateOptions(config);
     new AbilityCheckReminder(actor, abilityId).updateOptions(config);
   }
 
@@ -120,14 +101,8 @@ export default class CoreRollerHooks {
 
     if (this.isFastForwarding(config)) return;
 
-    debug("checking for message effects on this skill check");
     new SkillMessage(actor, skillId).addMessage(config);
-    if (showSources) {
-      debug("checking for adv/dis effects to display their source");
-      new SkillSource(actor, skillId, true).updateOptions(config);
-    }
-
-    debug("checking for adv/dis effects on this skill check");
+    if (showSources) new SkillSource(actor, skillId, true).updateOptions(config);
     new SkillReminder(actor, skillId, this.checkArmorStealth).updateOptions(config);
   }
 
@@ -136,14 +111,8 @@ export default class CoreRollerHooks {
 
     if (this.isFastForwarding(config)) return;
 
-    debug("checking for message effects on this tool check");
     new AbilityCheckMessage(item.actor, item.system.ability).addMessage(config);
-    if (showSources) {
-      debug("checking for adv/dis effects to display their source");
-      new AbilityCheckSource(item.actor, item.system.ability).updateOptions(config);
-    }
-
-    debug("checking for adv/dis effects on this tool check");
+    if (showSources) new AbilityCheckSource(item.actor, item.system.ability).updateOptions(config);
     new AbilityCheckReminder(item.actor, item.system.ability).updateOptions(config);
   }
 
@@ -152,32 +121,19 @@ export default class CoreRollerHooks {
 
     if (this.isFastForwarding(config)) return;
 
-    debug("checking for message effects on this death save");
     new DeathSaveMessage(actor).addMessage(config);
-    if (showSources) {
-      debug("checking for adv/dis effects to display their source");
-      new DeathSaveSource(actor).updateOptions(config);
-    }
-
-    debug("checking for adv/dis effects on this death save");
+    if (showSources) new DeathSaveSource(actor).updateOptions(config);
     new DeathSaveReminder(actor).updateOptions(config);
   }
 
   preRollDamage(item, config) {
     debug("preRollDamage hook called");
 
-    // check for critical flags unless the user pressed a fast-forward key
     if (this.isFastForwarding(config)) return;
     const target = getTarget();
 
-    debug("checking for message effects on this damage roll");
     new DamageMessage(item.actor, target, item).addMessage(config);
-    if (showSources) {
-      debug("checking for adv/dis effects to display their source");
-      new CriticalSource(item.actor, target, item).updateOptions(config);
-    }
-
-    debug("checking for critical/normal effects on this damage roll");
+    if (showSources) new CriticalSource(item.actor, target, item).updateOptions(config);
     new CriticalReminder(item.actor, target, item).updateOptions(config);
   }
 

--- a/src/rollers/core.js
+++ b/src/rollers/core.js
@@ -26,9 +26,9 @@ import {
 import { showSources } from "../settings.js";
 import { debug, getTarget } from "../util.js";
 
-// the core behavior, no other roller modules
-// meant for setting up and defining the "dnd5e.pre???" hooks
-
+/**
+ * Setup the dnd5e.preRoll hooks for use with the core roller.
+ */
 export default class CoreRollerHooks {
   /**
    * If true, check armor for stealth checks.
@@ -36,7 +36,9 @@ export default class CoreRollerHooks {
    */
   checkArmorStealth;
 
-  // setup everything specific to the roller
+  /**
+   * Initialize the hooks.
+   */
   init() {
     // DAE version 0.8.81 added support for "impose stealth disadvantage"
     this.checkArmorStealth = !game.modules.get("dae")?.active;
@@ -52,8 +54,10 @@ export default class CoreRollerHooks {
     Hooks.on("dnd5e.preRollDamage", this.preRollDamage.bind(this));
   }
 
-  // applying Midi flags should be done outside this class,
-  // but we'll ask whether to do it or not here
+  /**
+   * Returns a boolean to tell whether or not to handle Midi's flags
+   * @returns true to register a hook to handle Midi's flags, false otherwise
+   */
   shouldApplyMidiActiveEffect() {
     return true;
   }

--- a/src/rollers/core.js
+++ b/src/rollers/core.js
@@ -15,7 +15,6 @@ import {
   DeathSaveReminder,
   SkillReminder,
 } from "../reminders.js";
-import { showSources } from "../settings.js";
 import {
   AbilityCheckSource,
   AbilitySaveSource,
@@ -24,12 +23,13 @@ import {
   DeathSaveSource,
   SkillSource,
 } from "../sources.js";
+import { showSources } from "../settings.js";
 import { debug, getTarget } from "../util.js";
 
 // the core behavior, no other roller modules
 // meant for setting up and defining the "dnd5e.pre???" hooks
 
-export default class CoreRollHooks {
+export default class CoreRollerHooks {
   /**
    * If true, check armor for stealth checks.
    * @type {boolean}

--- a/src/rollers/midi.js
+++ b/src/rollers/midi.js
@@ -32,12 +32,8 @@ export default class MidiRollerHooks extends CoreRollerHooks {
     if (this.isFastForwarding(config)) return;
     const target = getTarget();
 
-    debug("checking for message effects on this attack roll");
     new AttackMessage(item.actor, target, item).addMessage(config);
-    if (showSources) {
-      debug("checking for adv/dis effects to display their source");
-      new AttackSource(item.actor, target, item).updateOptions(config);
-    }
+    if (showSources) new AttackSource(item.actor, target, item).updateOptions(config);
   }
 
   preRollAbilitySave(actor, config, abilityId) {
@@ -45,12 +41,8 @@ export default class MidiRollerHooks extends CoreRollerHooks {
 
     if (this.isFastForwarding(config)) return;
 
-    debug("checking for message effects on this saving throw");
     new AbilitySaveMessage(actor, abilityId).addMessage(config);
-    if (showSources) {
-      debug("checking for adv/dis effects to display their source");
-      new AbilitySaveSource(actor, abilityId).updateOptions(config);
-    }
+    if (showSources) new AbilitySaveSource(actor, abilityId).updateOptions(config);
   }
 
   preRollAbilityTest(actor, config, abilityId) {
@@ -58,12 +50,8 @@ export default class MidiRollerHooks extends CoreRollerHooks {
 
     if (this.isFastForwarding(config)) return;
 
-    debug("checking for message effects on this ability check");
     new AbilityCheckMessage(actor, abilityId).addMessage(config);
-    if (showSources) {
-      debug("checking for adv/dis effects to display their source");
-      new AbilityCheckSource(actor, abilityId).updateOptions(config);
-    }
+    if (showSources) new AbilityCheckSource(actor, abilityId).updateOptions(config);
   }
 
   preRollSkill(actor, config, skillId) {
@@ -71,12 +59,8 @@ export default class MidiRollerHooks extends CoreRollerHooks {
 
     if (this.isFastForwarding(config)) return;
 
-    debug("checking for message effects on this skill check");
     new SkillMessage(actor, skillId).addMessage(config);
-    if (showSources) {
-      debug("checking for adv/dis effects to display their source");
-      new SkillSource(actor, skillId, true).updateOptions(config);
-    }
+    if (showSources) new SkillSource(actor, skillId, true).updateOptions(config);
   }
 
   preRollToolCheck(item, config) {
@@ -84,12 +68,8 @@ export default class MidiRollerHooks extends CoreRollerHooks {
 
     if (this.isFastForwarding(config)) return;
 
-    debug("checking for message effects on this tool check");
     new AbilityCheckMessage(item.actor, item.system.ability).addMessage(config);
-    if (showSources) {
-      debug("checking for adv/dis effects to display their source");
-      new AbilityCheckSource(item.actor, item.system.ability).updateOptions(config);
-    }
+    if (showSources) new AbilityCheckSource(item.actor, item.system.ability).updateOptions(config);
   }
 
   preRollDeathSave(actor, config) {
@@ -97,26 +77,17 @@ export default class MidiRollerHooks extends CoreRollerHooks {
 
     if (this.isFastForwarding(config)) return;
 
-    debug("checking for message effects on this death save");
     new DeathSaveMessage(actor).addMessage(config);
-    if (showSources) {
-      debug("checking for adv/dis effects to display their source");
-      new DeathSaveSource(actor).updateOptions(config);
-    }
+    if (showSources) new DeathSaveSource(actor).updateOptions(config);
   }
 
   preRollDamage(item, config) {
     debug("preRollDamage hook called");
 
-    // check for critical flags unless the user pressed a fast-forward key
     if (this.isFastForwarding(config)) return;
     const target = getTarget();
 
-    debug("checking for message effects on this damage roll");
     new DamageMessage(item.actor, target, item).addMessage(config);
-    if (showSources) {
-      debug("checking for adv/dis effects to display their source");
-      new CriticalSource(item.actor, target, item).updateOptions(config);
-    }
+    if (showSources) new CriticalSource(item.actor, target, item).updateOptions(config);
   }
 }

--- a/src/rollers/midi.js
+++ b/src/rollers/midi.js
@@ -1,0 +1,119 @@
+import {
+  AbilityCheckMessage,
+  AbilitySaveMessage,
+  AttackMessage,
+  DamageMessage,
+  DeathSaveMessage,
+  SkillMessage,
+} from "../messages.js";
+import {
+  AbilityCheckSource,
+  AbilitySaveSource,
+  AttackSource,
+  CriticalSource,
+  DeathSaveSource,
+  SkillSource,
+} from "../sources.js";
+import { showSources } from "../settings.js";
+import { debug, getTarget } from "../util.js";
+import CoreRollHooks from "./core.js";
+
+export default class MidiRollerHooks extends CoreRollHooks {
+  shouldApplyMidiActiveEffect() {
+    return false;
+  }
+
+  preRollAttack(item, config) {
+    debug("preRollAttack hook called");
+
+    if (this.isFastForwarding(config)) return;
+    const target = getTarget();
+
+    debug("checking for message effects on this attack roll");
+    new AttackMessage(item.actor, target, item).addMessage(config);
+    if (showSources) {
+      debug("checking for adv/dis effects to display their source");
+      new AttackSource(item.actor, target, item).updateOptions(config);
+    }
+  }
+
+  preRollAbilitySave(actor, config, abilityId) {
+    debug("preRollAbilitySave hook called");
+
+    if (this.isFastForwarding(config)) return;
+
+    debug("checking for message effects on this saving throw");
+    new AbilitySaveMessage(actor, abilityId).addMessage(config);
+    if (showSources) {
+      debug("checking for adv/dis effects to display their source");
+      new AbilitySaveSource(actor, abilityId).updateOptions(config);
+    }
+  }
+
+  preRollAbilityTest(actor, config, abilityId) {
+    debug("preRollAbilityTest hook called");
+
+    if (this.isFastForwarding(config)) return;
+
+    debug("checking for message effects on this ability check");
+    new AbilityCheckMessage(actor, abilityId).addMessage(config);
+    if (showSources) {
+      debug("checking for adv/dis effects to display their source");
+      new AbilityCheckSource(actor, abilityId).updateOptions(config);
+    }
+  }
+
+  preRollSkill(actor, config, skillId) {
+    debug("preRollSkill hook called");
+
+    if (this.isFastForwarding(config)) return;
+
+    debug("checking for message effects on this skill check");
+    new SkillMessage(actor, skillId).addMessage(config);
+    if (showSources) {
+      debug("checking for adv/dis effects to display their source");
+      new SkillSource(actor, skillId, true).updateOptions(config);
+    }
+  }
+
+  preRollToolCheck(item, config) {
+    debug("preRollToolCheck hook called");
+
+    if (this.isFastForwarding(config)) return;
+
+    debug("checking for message effects on this tool check");
+    new AbilityCheckMessage(item.actor, item.system.ability).addMessage(config);
+    if (showSources) {
+      debug("checking for adv/dis effects to display their source");
+      new AbilityCheckSource(item.actor, item.system.ability).updateOptions(config);
+    }
+  }
+
+  preRollDeathSave(actor, config) {
+    debug("preRollDeathSave hook called");
+
+    if (this.isFastForwarding(config)) return;
+
+    debug("checking for message effects on this death save");
+    new DeathSaveMessage(actor).addMessage(config);
+    if (showSources) {
+      debug("checking for adv/dis effects to display their source");
+      new DeathSaveSource(actor).updateOptions(config);
+    }
+  }
+
+  preRollDamage(item, config) {
+    debug("preRollDamage hook called");
+
+    // check for critical flags unless the user pressed a fast-forward key
+    if (this.isFastForwarding(config)) return;
+    const target = getTarget();
+
+    debug("checking for message effects on this damage roll");
+    new DamageMessage(item.actor, target, item).addMessage(config);
+    if (showSources) {
+      debug("checking for adv/dis effects to display their source");
+      new CriticalSource(item.actor, target, item).updateOptions(config);
+    }
+  }
+}

--- a/src/rollers/midi.js
+++ b/src/rollers/midi.js
@@ -18,6 +18,9 @@ import { showSources } from "../settings.js";
 import { debug, getTarget } from "../util.js";
 import CoreRollerHooks from "./core.js";
 
+/**
+ * Setup the dnd5e.preRoll hooks for use with Midi-QOL.
+ */
 export default class MidiRollerHooks extends CoreRollerHooks {
   shouldApplyMidiActiveEffect() {
     return false;

--- a/src/rollers/midi.js
+++ b/src/rollers/midi.js
@@ -16,9 +16,9 @@ import {
 } from "../sources.js";
 import { showSources } from "../settings.js";
 import { debug, getTarget } from "../util.js";
-import CoreRollHooks from "./core.js";
+import CoreRollerHooks from "./core.js";
 
-export default class MidiRollerHooks extends CoreRollHooks {
+export default class MidiRollerHooks extends CoreRollerHooks {
   shouldApplyMidiActiveEffect() {
     return false;
   }

--- a/src/rollers/rsr.js
+++ b/src/rollers/rsr.js
@@ -31,18 +31,21 @@ export default class ReadySetRollHooks extends CoreRollerHooks {
   preRollAttack(item, config) {
     debug("preRollAttack hook called");
 
-    if (this.isFastForwarding(config)) return;
     const target = getTarget();
 
-    debug("checking for message effects on this attack roll");
-    new AttackMessage(item.actor, target, item).addMessage(config);
-    if (showSources) {
-      debug("checking for adv/dis effects to display their source");
-      new AttackSource(item.actor, target, item).updateOptions(config);
+    if (this._doMessages(config)) {
+      debug("checking for message effects on this attack roll");
+      new AttackMessage(item.actor, target, item).addMessage(config);
+      if (showSources) {
+        debug("checking for adv/dis effects to display their source");
+        new AttackSource(item.actor, target, item).updateOptions(config);
+      }
     }
 
-    debug("checking for adv/dis effects on this attack roll");
-    new AttackReminder(item.actor, target, item).updateOptions(config);
+    if (this._doReminder(config)) {
+      debug("checking for adv/dis effects on this attack roll");
+      new AttackReminder(item.actor, target, item).updateOptions(config);
+    }
   }
 
   preRollAbilitySave(actor, config, abilityId) {
@@ -52,98 +55,121 @@ export default class ReadySetRollHooks extends CoreRollerHooks {
     const failChecker = new AbilitySaveFail(actor, abilityId);
     if (failChecker.fails(config)) return false;
 
-    if (this.isFastForwarding(config)) return;
-
-    debug("checking for message effects on this saving throw");
-    new AbilitySaveMessage(actor, abilityId).addMessage(config);
-    if (showSources) {
-      debug("checking for adv/dis effects to display their source");
-      new AbilitySaveSource(actor, abilityId).updateOptions(config);
+    if (this._doMessages(config)) {
+      debug("checking for message effects on this saving throw");
+      new AbilitySaveMessage(actor, abilityId).addMessage(config);
+      if (showSources) {
+        debug("checking for adv/dis effects to display their source");
+        new AbilitySaveSource(actor, abilityId).updateOptions(config);
+      }
     }
 
-    debug("checking for adv/dis effects on this saving throw");
-    new AbilitySaveReminder(actor, abilityId).updateOptions(config);
+    if (this._doReminder(config)) {
+      debug("checking for adv/dis effects on this saving throw");
+      new AbilitySaveReminder(actor, abilityId).updateOptions(config);
+    }
   }
 
   preRollAbilityTest(actor, config, abilityId) {
     debug("preRollAbilityTest hook called");
 
-    if (this.isFastForwarding(config)) return;
-
-    debug("checking for message effects on this ability check");
-    new AbilityCheckMessage(actor, abilityId).addMessage(config);
-    if (showSources) {
-      debug("checking for adv/dis effects to display their source");
-      new AbilityCheckSource(actor, abilityId).updateOptions(config);
+    if (this._doMessages(config)) {
+      debug("checking for message effects on this ability check");
+      new AbilityCheckMessage(actor, abilityId).addMessage(config);
+      if (showSources) {
+        debug("checking for adv/dis effects to display their source");
+        new AbilityCheckSource(actor, abilityId).updateOptions(config);
+      }
     }
 
-    debug("checking for adv/dis effects on this ability check");
-    new AbilityCheckReminder(actor, abilityId).updateOptions(config);
+    if (this._doReminder(config)) {
+      debug("checking for adv/dis effects on this ability check");
+      new AbilityCheckReminder(actor, abilityId).updateOptions(config);
+    }
   }
 
   preRollSkill(actor, config, skillId) {
     debug("preRollSkill hook called");
 
-    if (this.isFastForwarding(config)) return;
-
-    debug("checking for message effects on this skill check");
-    new SkillMessage(actor, skillId).addMessage(config);
-    if (showSources) {
-      debug("checking for adv/dis effects to display their source");
-      new SkillSource(actor, skillId, true).updateOptions(config);
+    if (this._doMessages(config)) {
+      debug("checking for message effects on this skill check");
+      new SkillMessage(actor, skillId).addMessage(config);
+      if (showSources) {
+        debug("checking for adv/dis effects to display their source");
+        new SkillSource(actor, skillId, true).updateOptions(config);
+      }
     }
 
-    debug("checking for adv/dis effects on this skill check");
-    new SkillReminder(actor, skillId, this.checkArmorStealth).updateOptions(config);
+    if (this._doReminder(config)) {
+      debug("checking for adv/dis effects on this skill check");
+      new SkillReminder(actor, skillId, this.checkArmorStealth).updateOptions(config);
+    }
   }
 
   preRollToolCheck(item, config) {
     debug("preRollToolCheck hook called");
 
-    if (this.isFastForwarding(config)) return;
-
-    debug("checking for message effects on this tool check");
-    new AbilityCheckMessage(item.actor, item.system.ability).addMessage(config);
-    if (showSources) {
-      debug("checking for adv/dis effects to display their source");
-      new AbilityCheckSource(item.actor, item.system.ability).updateOptions(config);
+    if (this._doMessages(config)) {
+      debug("checking for message effects on this tool check");
+      new AbilityCheckMessage(item.actor, item.system.ability).addMessage(config);
+      if (showSources) {
+        debug("checking for adv/dis effects to display their source");
+        new AbilityCheckSource(item.actor, item.system.ability).updateOptions(config);
+      }
     }
 
-    debug("checking for adv/dis effects on this tool check");
-    new AbilityCheckReminder(item.actor, item.system.ability).updateOptions(config);
+    if (this._doReminder(config)) {
+      debug("checking for adv/dis effects on this tool check");
+      new AbilityCheckReminder(item.actor, item.system.ability).updateOptions(config);
+    }
   }
 
   preRollDeathSave(actor, config) {
     debug("preRollDeathSave hook called");
 
-    if (this.isFastForwarding(config)) return;
-
-    debug("checking for message effects on this death save");
-    new DeathSaveMessage(actor).addMessage(config);
-    if (showSources) {
-      debug("checking for adv/dis effects to display their source");
-      new DeathSaveSource(actor).updateOptions(config);
+    if (this._doMessages(config)) {
+      debug("checking for message effects on this death save");
+      new DeathSaveMessage(actor).addMessage(config);
+      if (showSources) {
+        debug("checking for adv/dis effects to display their source");
+        new DeathSaveSource(actor).updateOptions(config);
+      }
     }
 
-    debug("checking for adv/dis effects on this death save");
-    new DeathSaveReminder(actor).updateOptions(config);
+    if (this._doReminder(config)) {
+      debug("checking for adv/dis effects on this death save");
+      new DeathSaveReminder(actor).updateOptions(config);
+    }
   }
 
   preRollDamage(item, config) {
     debug("preRollDamage hook called");
 
-    // check for critical flags unless the user pressed a fast-forward key
-    if (this.isFastForwarding(config)) return;
     const target = getTarget();
 
-    debug("checking for message effects on this damage roll");
-    new DamageMessage(item.actor, target, item).addMessage(config);
-    if (showSources) {
-      debug("checking for adv/dis effects to display their source");
-      new CriticalSource(item.actor, target, item).updateOptions(config);
+    if (this._doMessages(config)) {
+      debug("checking for message effects on this damage roll");
+      new DamageMessage(item.actor, target, item).addMessage(config);
+      if (showSources) {
+        debug("checking for adv/dis effects to display their source");
+        new CriticalSource(item.actor, target, item).updateOptions(config);
+      }
     }
 
-    debug("checking for critical/normal effects on this damage roll");
-    new CriticalReminder(item.actor, target, item).updateOptions(config);
+    if (this._doReminder(config)) {
+      debug("checking for critical/normal effects on this damage roll");
+      new CriticalReminder(item.actor, target, item).updateOptions(config);
+    }
+  }
+
+  _doMessages({ fastForward = false }) {
+    if (fastForward) debug("fast-forwarding the roll, skip messages");
+    return !fastForward;
+  }
+
+  _doReminder({ advantage = false, disadvantage = false }) {
+    if (advantage) debug("advantage already set, skip reminder checks");
+    if (disadvantage) debug("disadvantage already set, skip reminder checks");
+    return !(advantage || disadvantage);
   }
 }

--- a/src/rollers/rsr.js
+++ b/src/rollers/rsr.js
@@ -167,9 +167,10 @@ export default class ReadySetRollHooks extends CoreRollerHooks {
     return !fastForward;
   }
 
-  _doReminder({ advantage = false, disadvantage = false }) {
+  _doReminder({ advantage = false, disadvantage = false, critical = false }) {
     if (advantage) debug("advantage already set, skip reminder checks");
     if (disadvantage) debug("disadvantage already set, skip reminder checks");
-    return !(advantage || disadvantage);
+    if (critical) debug("critical already set, skip reminder checks");
+    return !(advantage || disadvantage || critical);
   }
 }

--- a/src/rollers/rsr.js
+++ b/src/rollers/rsr.js
@@ -27,6 +27,9 @@ import { showSources } from "../settings.js";
 import { debug, getTarget } from "../util.js";
 import CoreRollerHooks from "./core.js";
 
+/**
+ * Setup the dnd5e.preRoll hooks for use with Ready Set Roll.
+ */
 export default class ReadySetRollHooks extends CoreRollerHooks {
   preRollAttack(item, config) {
     debug("preRollAttack hook called");

--- a/src/rollers/rsr.js
+++ b/src/rollers/rsr.js
@@ -37,112 +37,73 @@ export default class ReadySetRollHooks extends CoreRollerHooks {
     const target = getTarget();
 
     if (this._doMessages(config)) {
-      debug("checking for message effects on this attack roll");
       new AttackMessage(item.actor, target, item).addMessage(config);
-      if (showSources) {
-        debug("checking for adv/dis effects to display their source");
-        new AttackSource(item.actor, target, item).updateOptions(config);
-      }
+      if (showSources) new AttackSource(item.actor, target, item).updateOptions(config);
     }
 
-    if (this._doReminder(config)) {
-      debug("checking for adv/dis effects on this attack roll");
+    if (this._doReminder(config))
       new AttackReminder(item.actor, target, item).updateOptions(config);
-    }
   }
 
   preRollAbilitySave(actor, config, abilityId) {
     debug("preRollAbilitySave hook called");
 
-    // check if an effect says to fail this roll
     const failChecker = new AbilitySaveFail(actor, abilityId);
     if (failChecker.fails(config)) return false;
 
     if (this._doMessages(config)) {
-      debug("checking for message effects on this saving throw");
       new AbilitySaveMessage(actor, abilityId).addMessage(config);
-      if (showSources) {
-        debug("checking for adv/dis effects to display their source");
-        new AbilitySaveSource(actor, abilityId).updateOptions(config);
-      }
+      if (showSources) new AbilitySaveSource(actor, abilityId).updateOptions(config);
     }
 
-    if (this._doReminder(config)) {
-      debug("checking for adv/dis effects on this saving throw");
-      new AbilitySaveReminder(actor, abilityId).updateOptions(config);
-    }
+    if (this._doReminder(config)) new AbilitySaveReminder(actor, abilityId).updateOptions(config);
   }
 
   preRollAbilityTest(actor, config, abilityId) {
     debug("preRollAbilityTest hook called");
 
     if (this._doMessages(config)) {
-      debug("checking for message effects on this ability check");
       new AbilityCheckMessage(actor, abilityId).addMessage(config);
-      if (showSources) {
-        debug("checking for adv/dis effects to display their source");
-        new AbilityCheckSource(actor, abilityId).updateOptions(config);
-      }
+      if (showSources) new AbilityCheckSource(actor, abilityId).updateOptions(config);
     }
 
-    if (this._doReminder(config)) {
-      debug("checking for adv/dis effects on this ability check");
-      new AbilityCheckReminder(actor, abilityId).updateOptions(config);
-    }
+    if (this._doReminder(config)) new AbilityCheckReminder(actor, abilityId).updateOptions(config);
   }
 
   preRollSkill(actor, config, skillId) {
     debug("preRollSkill hook called");
 
     if (this._doMessages(config)) {
-      debug("checking for message effects on this skill check");
       new SkillMessage(actor, skillId).addMessage(config);
-      if (showSources) {
-        debug("checking for adv/dis effects to display their source");
-        new SkillSource(actor, skillId, true).updateOptions(config);
-      }
+      if (showSources) new SkillSource(actor, skillId, true).updateOptions(config);
     }
 
-    if (this._doReminder(config)) {
-      debug("checking for adv/dis effects on this skill check");
+    if (this._doReminder(config))
       new SkillReminder(actor, skillId, this.checkArmorStealth).updateOptions(config);
-    }
   }
 
   preRollToolCheck(item, config) {
     debug("preRollToolCheck hook called");
 
     if (this._doMessages(config)) {
-      debug("checking for message effects on this tool check");
       new AbilityCheckMessage(item.actor, item.system.ability).addMessage(config);
-      if (showSources) {
-        debug("checking for adv/dis effects to display their source");
+      if (showSources)
         new AbilityCheckSource(item.actor, item.system.ability).updateOptions(config);
-      }
     }
 
-    if (this._doReminder(config)) {
-      debug("checking for adv/dis effects on this tool check");
+    if (this._doReminder(config))
       new AbilityCheckReminder(item.actor, item.system.ability).updateOptions(config);
-    }
   }
 
   preRollDeathSave(actor, config) {
     debug("preRollDeathSave hook called");
 
     if (this._doMessages(config)) {
-      debug("checking for message effects on this death save");
       new DeathSaveMessage(actor).addMessage(config);
-      if (showSources) {
-        debug("checking for adv/dis effects to display their source");
-        new DeathSaveSource(actor).updateOptions(config);
-      }
+      if (showSources) new DeathSaveSource(actor).updateOptions(config);
     }
 
-    if (this._doReminder(config)) {
-      debug("checking for adv/dis effects on this death save");
-      new DeathSaveReminder(actor).updateOptions(config);
-    }
+    if (this._doReminder(config)) new DeathSaveReminder(actor).updateOptions(config);
   }
 
   preRollDamage(item, config) {
@@ -151,12 +112,8 @@ export default class ReadySetRollHooks extends CoreRollerHooks {
     const target = getTarget();
 
     if (this._doMessages(config)) {
-      debug("checking for message effects on this damage roll");
       new DamageMessage(item.actor, target, item).addMessage(config);
-      if (showSources) {
-        debug("checking for adv/dis effects to display their source");
-        new CriticalSource(item.actor, target, item).updateOptions(config);
-      }
+      if (showSources) new CriticalSource(item.actor, target, item).updateOptions(config);
     }
 
     // don't use CriticalReminder because it causes problems with the damage roll

--- a/src/rollers/rsr.js
+++ b/src/rollers/rsr.js
@@ -1,0 +1,149 @@
+import { AbilitySaveFail } from "../fails.js";
+import {
+  AbilityCheckMessage,
+  AbilitySaveMessage,
+  AttackMessage,
+  DamageMessage,
+  DeathSaveMessage,
+  SkillMessage,
+} from "../messages.js";
+import {
+  AttackReminder,
+  AbilityCheckReminder,
+  AbilitySaveReminder,
+  CriticalReminder,
+  DeathSaveReminder,
+  SkillReminder,
+} from "../reminders.js";
+import {
+  AbilityCheckSource,
+  AbilitySaveSource,
+  AttackSource,
+  CriticalSource,
+  DeathSaveSource,
+  SkillSource,
+} from "../sources.js";
+import { showSources } from "../settings.js";
+import { debug, getTarget } from "../util.js";
+import CoreRollerHooks from "./core.js";
+
+export default class ReadySetRollHooks extends CoreRollerHooks {
+  preRollAttack(item, config) {
+    debug("preRollAttack hook called");
+
+    if (this.isFastForwarding(config)) return;
+    const target = getTarget();
+
+    debug("checking for message effects on this attack roll");
+    new AttackMessage(item.actor, target, item).addMessage(config);
+    if (showSources) {
+      debug("checking for adv/dis effects to display their source");
+      new AttackSource(item.actor, target, item).updateOptions(config);
+    }
+
+    debug("checking for adv/dis effects on this attack roll");
+    new AttackReminder(item.actor, target, item).updateOptions(config);
+  }
+
+  preRollAbilitySave(actor, config, abilityId) {
+    debug("preRollAbilitySave hook called");
+
+    // check if an effect says to fail this roll
+    const failChecker = new AbilitySaveFail(actor, abilityId);
+    if (failChecker.fails(config)) return false;
+
+    if (this.isFastForwarding(config)) return;
+
+    debug("checking for message effects on this saving throw");
+    new AbilitySaveMessage(actor, abilityId).addMessage(config);
+    if (showSources) {
+      debug("checking for adv/dis effects to display their source");
+      new AbilitySaveSource(actor, abilityId).updateOptions(config);
+    }
+
+    debug("checking for adv/dis effects on this saving throw");
+    new AbilitySaveReminder(actor, abilityId).updateOptions(config);
+  }
+
+  preRollAbilityTest(actor, config, abilityId) {
+    debug("preRollAbilityTest hook called");
+
+    if (this.isFastForwarding(config)) return;
+
+    debug("checking for message effects on this ability check");
+    new AbilityCheckMessage(actor, abilityId).addMessage(config);
+    if (showSources) {
+      debug("checking for adv/dis effects to display their source");
+      new AbilityCheckSource(actor, abilityId).updateOptions(config);
+    }
+
+    debug("checking for adv/dis effects on this ability check");
+    new AbilityCheckReminder(actor, abilityId).updateOptions(config);
+  }
+
+  preRollSkill(actor, config, skillId) {
+    debug("preRollSkill hook called");
+
+    if (this.isFastForwarding(config)) return;
+
+    debug("checking for message effects on this skill check");
+    new SkillMessage(actor, skillId).addMessage(config);
+    if (showSources) {
+      debug("checking for adv/dis effects to display their source");
+      new SkillSource(actor, skillId, true).updateOptions(config);
+    }
+
+    debug("checking for adv/dis effects on this skill check");
+    new SkillReminder(actor, skillId, this.checkArmorStealth).updateOptions(config);
+  }
+
+  preRollToolCheck(item, config) {
+    debug("preRollToolCheck hook called");
+
+    if (this.isFastForwarding(config)) return;
+
+    debug("checking for message effects on this tool check");
+    new AbilityCheckMessage(item.actor, item.system.ability).addMessage(config);
+    if (showSources) {
+      debug("checking for adv/dis effects to display their source");
+      new AbilityCheckSource(item.actor, item.system.ability).updateOptions(config);
+    }
+
+    debug("checking for adv/dis effects on this tool check");
+    new AbilityCheckReminder(item.actor, item.system.ability).updateOptions(config);
+  }
+
+  preRollDeathSave(actor, config) {
+    debug("preRollDeathSave hook called");
+
+    if (this.isFastForwarding(config)) return;
+
+    debug("checking for message effects on this death save");
+    new DeathSaveMessage(actor).addMessage(config);
+    if (showSources) {
+      debug("checking for adv/dis effects to display their source");
+      new DeathSaveSource(actor).updateOptions(config);
+    }
+
+    debug("checking for adv/dis effects on this death save");
+    new DeathSaveReminder(actor).updateOptions(config);
+  }
+
+  preRollDamage(item, config) {
+    debug("preRollDamage hook called");
+
+    // check for critical flags unless the user pressed a fast-forward key
+    if (this.isFastForwarding(config)) return;
+    const target = getTarget();
+
+    debug("checking for message effects on this damage roll");
+    new DamageMessage(item.actor, target, item).addMessage(config);
+    if (showSources) {
+      debug("checking for adv/dis effects to display their source");
+      new CriticalSource(item.actor, target, item).updateOptions(config);
+    }
+
+    debug("checking for critical/normal effects on this damage roll");
+    new CriticalReminder(item.actor, target, item).updateOptions(config);
+  }
+}

--- a/src/rollers/rsr.js
+++ b/src/rollers/rsr.js
@@ -31,6 +31,13 @@ import CoreRollerHooks from "./core.js";
  * Setup the dnd5e.preRoll hooks for use with Ready Set Roll.
  */
 export default class ReadySetRollHooks extends CoreRollerHooks {
+  init() {
+    super.init();
+
+    // register another hook for CriticalReminder
+    Hooks.on("dnd5e.useItem", this.useItem.bind(this));
+  }
+
   preRollAttack(item, config) {
     debug("preRollAttack hook called");
 
@@ -115,9 +122,15 @@ export default class ReadySetRollHooks extends CoreRollerHooks {
       new DamageMessage(item.actor, target, item).addMessage(config);
       if (showSources) new CriticalSource(item.actor, target, item).updateOptions(config);
     }
+    // don't use CriticalReminder here, it's done in another hook
+  }
 
-    // don't use CriticalReminder because it causes problems with the damage roll
-    // TODO https://github.com/MangoFVTT/fvtt-ready-set-roll-5e/issues/184
+  useItem(item, config, options) {
+    debug("useItem hook called");
+
+    // check for critical hits but set the "isCrit" property instead of the default "critical"
+    const target = getTarget();
+    new CriticalReminder(item.actor, target, item).updateOptions(config, "isCrit");
   }
 
   _doMessages({ fastForward = false }) {

--- a/src/rollers/rsr.js
+++ b/src/rollers/rsr.js
@@ -156,10 +156,8 @@ export default class ReadySetRollHooks extends CoreRollerHooks {
       }
     }
 
-    if (this._doReminder(config)) {
-      debug("checking for critical/normal effects on this damage roll");
-      new CriticalReminder(item.actor, target, item).updateOptions(config);
-    }
+    // don't use CriticalReminder because it causes problems with the damage roll
+    // TODO https://github.com/MangoFVTT/fvtt-ready-set-roll-5e/issues/184
   }
 
   _doMessages({ fastForward = false }) {
@@ -167,10 +165,9 @@ export default class ReadySetRollHooks extends CoreRollerHooks {
     return !fastForward;
   }
 
-  _doReminder({ advantage = false, disadvantage = false, critical = false }) {
+  _doReminder({ advantage = false, disadvantage = false }) {
     if (advantage) debug("advantage already set, skip reminder checks");
     if (disadvantage) debug("disadvantage already set, skip reminder checks");
-    if (critical) debug("critical already set, skip reminder checks");
-    return !(advantage || disadvantage || critical);
+    return !(advantage || disadvantage);
   }
 }

--- a/src/sources.js
+++ b/src/sources.js
@@ -31,6 +31,10 @@ const SourceMixin = (superclass) =>
       }, {});
     }
 
+    _message() {
+      debug("checking for adv/dis effects to display their source");
+    }
+
     _accumulator() {
       const advantageLabels = [];
       const disadvantageLabels = [];

--- a/src/util.js
+++ b/src/util.js
@@ -20,3 +20,11 @@ export function isMinVersion(name, version) {
   const module = game.modules.get(name);
   return module?.active && isNewerVersion(module.version, version);
 }
+
+/**
+   * Get the first targeted actor, if there are any targets at all.
+   * @returns {Actor5e} the first target, if there are any
+   */
+export function getTarget() {
+  return [...game.user.targets][0]?.actor;
+}

--- a/src/util.js
+++ b/src/util.js
@@ -22,9 +22,9 @@ export function isMinVersion(name, version) {
 }
 
 /**
-   * Get the first targeted actor, if there are any targets at all.
-   * @returns {Actor5e} the first target, if there are any
-   */
+ * Get the first targeted actor, if there are any targets at all.
+ * @returns {Actor5e} the first target, if there are any
+ */
 export function getTarget() {
   return [...game.user.targets][0]?.actor;
 }


### PR DESCRIPTION
Refactor the module a bit by pulling out the `dnd5e.pre???` hook code into new classes. This will allow better customization for the different roller modules. Since there was already support for Core and Midi, those were the first two classes added that work the same as before. Then added a third class for Ready Set Roll to add better support for it.

Now w/ RSR enabled it will do adv/dis processing as long as you don't hold down one of the roll modifier keys. While the `config` object passed to my hook doesn't have the `event`, I can see if adv/dis are already set to `true` and use that. I did have to turn off critical processing since it caused a bug w/ RSR (MangoFVTT/fvtt-ready-set-roll-5e#184).