### PR TITLE
dnd5e 3.0 updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - bug fix: 3.0.0 compatibility for Messages and Souces from effects on items
 - bug fix: 3.0.0 compatibility with new stealthDisadvantage property
+- bug fix: use `name` instead of `label` on effect to remove deprecation warning
 - feature: now requires dnd5e 3.0.0 and thus, Foundry 11
 
 # 3.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 3.3.0
 
 - bug fix: 3.0.0 compatibility for Messages and Souces from effects on items
+- bug fix: 3.0.0 compatibility with new stealthDisadvantage property
 - feature: now requires dnd5e 3.0.0 and thus, Foundry 11
 
 # 3.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 3.3.0
+
+- bug fix: 3.0.0 compatibility for Messages and Souces from effects on items
+- feature: now requires dnd5e 3.0.0 and thus, Foundry 11
+
 # 3.2.1
 
 - bug fix: tweak how messages are added to the dialog to remove a conflict with another module that also changes that dialog

--- a/module.json
+++ b/module.json
@@ -5,11 +5,22 @@
   "authors": [{ "name": "kaelad", "discord": "kaelad#1693" }],
   "version": "0.1",
   "compatibility": {
-    "minimum": "10",
+    "minimum": "11",
     "verified": "11"
   },
   "relationships": {
-    "systems": [{ "id": "dnd5e" }, { "id": "sw5e" }]
+    "systems": [
+      {
+        "id": "dnd5e",
+        "compatibility": {
+          "minimum": "3.0.0",
+          "verified": "3.0.0"
+        }
+      },
+      {
+        "id": "sw5e"
+      }
+    ]
   },
   "esmodules": ["src/module.js", "src/settings.js"],
   "styles": ["css/adv-reminder.css"],

--- a/src/messages.js
+++ b/src/messages.js
@@ -12,8 +12,7 @@ class BaseMessage {
 
   _getActiveEffectKeys(actor) {
     return actor
-      ? actor.effects
-          .filter((effect) => !effect.isSuppressed && !effect.disabled)
+      ? actor.appliedEffects
           .flatMap((effect) => effect.changes)
           .sort((a, b) => a.priority - b.priority)
       : [];

--- a/src/reminders.js
+++ b/src/reminders.js
@@ -213,7 +213,7 @@ export class SkillReminder extends AbilityCheckReminder {
   _armorStealthDisadvantage() {
     if (this.skillId === "ste") {
       const item = this.items.find(
-        (item) => item.type === "equipment" && item.system?.equipped && item.system?.stealth
+        (item) => item.type === "equipment" && item.system.equipped && item.system.properties.has("stealthDisadvantage")
       );
       debug("equiped item that imposes stealth disadvantage", item?.name);
       return item?.name;

--- a/src/sources.js
+++ b/src/sources.js
@@ -17,7 +17,7 @@ const SourceMixin = (superclass) =>
         .flatMap((effect) =>
           // make an object with the effect's label and change's key
           effect.changes.map((change) => ({
-            label: effect.label,
+            name: effect.name,
             key: change.key,
           }))
         )
@@ -25,7 +25,7 @@ const SourceMixin = (superclass) =>
       asArray.forEach((change) => (change.key = change.key.substring(15)));
       return asArray.reduce((accum, curr) => {
         if (!accum[curr.key]) accum[curr.key] = [];
-        accum[curr.key].push(curr.label);
+        accum[curr.key].push(curr.name);
         return accum;
       }, {});
     }

--- a/src/sources.js
+++ b/src/sources.js
@@ -13,8 +13,7 @@ const SourceMixin = (superclass) =>
     _getFlags(actor) {
       if (!actor) return {};
 
-      const asArray = actor.effects
-        .filter((effect) => !effect.isSuppressed && !effect.disabled)
+      const asArray = actor.appliedEffects
         .flatMap((effect) =>
           // make an object with the effect's label and change's key
           effect.changes.map((change) => ({

--- a/test/messages.test.js
+++ b/test/messages.test.js
@@ -23,7 +23,7 @@ globalThis.setProperty = (object, key, value) => {
 };
 
 function createActorWithEffects(...keyValuePairs) {
-  const effects = keyValuePairs.map(createEffect);
+  const appliedEffects = keyValuePairs.map(createEffect);
   return {
     system: {
       skills: {
@@ -83,14 +83,13 @@ function createActorWithEffects(...keyValuePairs) {
         },
       },
     },
-    effects,
+    appliedEffects,
     getRollData: () => ({}),
   };
 }
 
 function createEffect([key, value]) {
   return {
-    isSuppressed: false,
     changes: [
       {
         key,
@@ -98,8 +97,7 @@ function createEffect([key, value]) {
         mode: 0,
         priority: "0",
       },
-    ],
-    disabled: false,
+    ]
   };
 }
 
@@ -115,28 +113,6 @@ function createItem(actionType, abilityMod) {
 describe("AttackMessage no legit active effects", () => {
   test("attack with no active effects should not add a message", () => {
     const actor = createActorWithEffects();
-    const item = createItem("mwak", "str");
-    const options = {};
-
-    new AttackMessage(actor, undefined, item).addMessage(options);
-
-    expect(options.dialogOptions).toBeUndefined();
-  });
-
-  test("attack with a suppressed active effect should not add a message", () => {
-    const actor = createActorWithEffects(["flags.adv-reminder.message.all", "some message"]);
-    actor.effects[0].isSuppressed = true;
-    const item = createItem("mwak", "str");
-    const options = {};
-
-    new AttackMessage(actor, undefined, item).addMessage(options);
-
-    expect(options.dialogOptions).toBeUndefined();
-  });
-
-  test("attack with a disabled active effect should not add a message", () => {
-    const actor = createActorWithEffects(["flags.adv-reminder.message.all", "some message"]);
-    actor.effects[0].disabled = true;
     const item = createItem("mwak", "str");
     const options = {};
 
@@ -343,26 +319,6 @@ describe("AbilityCheckMessage no legit active effects", () => {
 
     expect(options.dialogOptions).toBeUndefined();
   });
-
-  test("ability check with a suppressed active effect should not add a message", () => {
-    const actor = createActorWithEffects(["flags.adv-reminder.message.all", "some message"]);
-    actor.effects[0].isSuppressed = true;
-    const options = {};
-
-    new AbilityCheckMessage(actor, "int").addMessage(options);
-
-    expect(options.dialogOptions).toBeUndefined();
-  });
-
-  test("ability check with a disabled active effect should not add a message", () => {
-    const actor = createActorWithEffects(["flags.adv-reminder.message.all", "some message"]);
-    actor.effects[0].disabled = true;
-    const options = {};
-
-    new AbilityCheckMessage(actor, "int").addMessage(options);
-
-    expect(options.dialogOptions).toBeUndefined();
-  });
 });
 
 describe("AbilityCheckMessage message flags", () => {
@@ -451,26 +407,6 @@ describe("AbilitySaveMessage no legit active effects", () => {
 
     expect(options.dialogOptions).toBeUndefined();
   });
-
-  test("saving throw with a suppressed active effect should not add a message", () => {
-    const actor = createActorWithEffects(["flags.adv-reminder.message.all", "some message"]);
-    actor.effects[0].isSuppressed = true;
-    const options = {};
-
-    new AbilitySaveMessage(actor, "int").addMessage(options);
-
-    expect(options.dialogOptions).toBeUndefined();
-  });
-
-  test("saving throw with a disabled active effect should not add a message", () => {
-    const actor = createActorWithEffects(["flags.adv-reminder.message.all", "some message"]);
-    actor.effects[0].disabled = true;
-    const options = {};
-
-    new AbilitySaveMessage(actor, "int").addMessage(options);
-
-    expect(options.dialogOptions).toBeUndefined();
-  });
 });
 
 describe("AbilitySaveMessage message flags", () => {
@@ -553,26 +489,6 @@ describe("AbilitySaveMessage message flags", () => {
 describe("SkillMessage no legit active effects", () => {
   test("skill check with no active effects should not add a message", () => {
     const actor = createActorWithEffects();
-    const options = {};
-
-    new SkillMessage(actor, "ath").addMessage(options);
-
-    expect(options.dialogOptions).toBeUndefined();
-  });
-
-  test("skill check with a suppressed active effect should not add a message", () => {
-    const actor = createActorWithEffects(["flags.adv-reminder.message.all", "some message"]);
-    actor.effects[0].isSuppressed = true;
-    const options = {};
-
-    new SkillMessage(actor, "ath").addMessage(options);
-
-    expect(options.dialogOptions).toBeUndefined();
-  });
-
-  test("skill check with a disabled active effect should not add a message", () => {
-    const actor = createActorWithEffects(["flags.adv-reminder.message.all", "some message"]);
-    actor.effects[0].disabled = true;
     const options = {};
 
     new SkillMessage(actor, "ath").addMessage(options);
@@ -707,26 +623,6 @@ describe("DeathSaveMessage no legit active effects", () => {
 
     expect(options.dialogOptions).toBeUndefined();
   });
-
-  test("death save with a suppressed active effect should not add a message", () => {
-    const actor = createActorWithEffects(["flags.adv-reminder.message.all", "some message"]);
-    actor.effects[0].isSuppressed = true;
-    const options = {};
-
-    new DeathSaveMessage(actor).addMessage(options);
-
-    expect(options.dialogOptions).toBeUndefined();
-  });
-
-  test("death save with a disabled active effect should not add a message", () => {
-    const actor = createActorWithEffects(["flags.adv-reminder.message.all", "some message"]);
-    actor.effects[0].disabled = true;
-    const options = {};
-
-    new DeathSaveMessage(actor).addMessage(options);
-
-    expect(options.dialogOptions).toBeUndefined();
-  });
 });
 
 describe("DeathSaveMessage message flags", () => {
@@ -797,28 +693,6 @@ describe("DeathSaveMessage message flags", () => {
 describe("DamageMessage no legit active effects", () => {
   test("damage with no active effects should not add a message", () => {
     const actor = createActorWithEffects();
-    const item = createItem("mwak", "str");
-    const options = {};
-
-    new DamageMessage(actor, undefined, item).addMessage(options);
-
-    expect(options.dialogOptions).toBeUndefined();
-  });
-
-  test("damage with a suppressed active effect should not add a message", () => {
-    const actor = createActorWithEffects(["flags.adv-reminder.message.all", "some message"]);
-    actor.effects[0].isSuppressed = true;
-    const item = createItem("mwak", "str");
-    const options = {};
-
-    new DamageMessage(actor, undefined, item).addMessage(options);
-
-    expect(options.dialogOptions).toBeUndefined();
-  });
-
-  test("damage with a disabled active effect should not add a message", () => {
-    const actor = createActorWithEffects(["flags.adv-reminder.message.all", "some message"]);
-    actor.effects[0].disabled = true;
     const item = createItem("mwak", "str");
     const options = {};
 

--- a/test/reminders.test.js
+++ b/test/reminders.test.js
@@ -669,7 +669,7 @@ describe("SkillReminder no legit active effects", () => {
         type: "spell",
         system: {
           equipped: true,
-          stealth: true,
+          properties: new Set(["stealthDisadvantage"]),
         },
       },
     ];
@@ -690,7 +690,7 @@ describe("SkillReminder no legit active effects", () => {
         type: "equipment",
         system: {
           equipped: false,
-          stealth: true,
+          properties: new Set(["stealthDisadvantage"]),
         },
       },
     ];
@@ -891,7 +891,7 @@ describe("SkillReminder disadvantage flags", () => {
         type: "equipment",
         system: {
           equipped: true,
-          stealth: true,
+          properties: new Set(["stealthDisadvantage"]),
         },
       },
     ];
@@ -912,7 +912,7 @@ describe("SkillReminder disadvantage flags", () => {
         type: "equipment",
         system: {
           equipped: true,
-          stealth: true,
+          properties: new Set(["stealthDisadvantage"]),
         },
       },
     ];


### PR DESCRIPTION
While AR worked with the dnd5e 3.0 update for the most part, there were a few issues that this fixes:
- getting Messages and Souces from active effects on items (part of the switch from the legacy transferral mode)
- a deprecation warning since `stealth` was moved into the generic `properties`