### PR TITLE
Adapt to some skill and tool changes the system made, fixing #60

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 3.3.2
 
 - bug fix: [#60](https://github.com/kaelad02/adv-reminder/issues/60) Fix tool checks to show advantage and messages again after the check was moved from the item to the actor
+- bug fix: Honor the ability you can pass into the `rollSkill` function, overriding the normal ability used for a skill. Examples would be a macro or using the new enricher to make a Strength (Intimidation) check.
 
 # 3.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.3.2
+
+- bug fix: [#60](https://github.com/kaelad02/adv-reminder/issues/60) Fix tool checks to show advantage and messages again after the check was moved from the item to the actor
+
 # 3.3.1
 
 - bug fix: [#56](https://github.com/kaelad02/adv-reminder/issues/56) Fully support messages on damage rolls other than attacks

--- a/src/messages.js
+++ b/src/messages.js
@@ -115,8 +115,8 @@ export class AbilitySaveMessage extends AbilityBaseMessage {
 }
 
 export class SkillMessage extends AbilityCheckMessage {
-  constructor(actor, skillId) {
-    super(actor, actor.system.skills[skillId].ability);
+  constructor(actor, abilityId, skillId) {
+    super(actor, abilityId);
 
     /** @type {string} */
     this.skillId = skillId;

--- a/src/reminders.js
+++ b/src/reminders.js
@@ -164,8 +164,8 @@ export class AbilitySaveReminder extends AbilityBaseReminder {
 }
 
 export class SkillReminder extends AbilityCheckReminder {
-  constructor(actor, skillId, checkArmorStealth = true) {
-    super(actor, actor.system.skills[skillId].ability);
+  constructor(actor, abilityId, skillId, checkArmorStealth = true) {
+    super(actor, abilityId);
 
     /** @type {string} */
     this.skillId = skillId;

--- a/src/rollers/core.js
+++ b/src/rollers/core.js
@@ -101,9 +101,10 @@ export default class CoreRollerHooks {
 
     if (this.isFastForwarding(config)) return;
 
-    new SkillMessage(actor, skillId).addMessage(config);
-    if (showSources) new SkillSource(actor, skillId, true).updateOptions(config);
-    new SkillReminder(actor, skillId, this.checkArmorStealth).updateOptions(config);
+    const ability = config.data.defaultAbility;
+    new SkillMessage(actor, ability, skillId).addMessage(config);
+    if (showSources) new SkillSource(actor, ability, skillId, true).updateOptions(config);
+    new SkillReminder(actor, ability, skillId, this.checkArmorStealth).updateOptions(config);
   }
 
   preRollToolCheck(actor, config, toolId) {

--- a/src/rollers/core.js
+++ b/src/rollers/core.js
@@ -106,14 +106,15 @@ export default class CoreRollerHooks {
     new SkillReminder(actor, skillId, this.checkArmorStealth).updateOptions(config);
   }
 
-  preRollToolCheck(item, config) {
+  preRollToolCheck(actor, config, toolId) {
     debug("preRollToolCheck hook called");
 
     if (this.isFastForwarding(config)) return;
 
-    new AbilityCheckMessage(item.actor, item.system.ability).addMessage(config);
-    if (showSources) new AbilityCheckSource(item.actor, item.system.ability).updateOptions(config);
-    new AbilityCheckReminder(item.actor, item.system.ability).updateOptions(config);
+    const ability = config.data.defaultAbility;
+    new AbilityCheckMessage(actor, ability).addMessage(config);
+    if (showSources) new AbilityCheckSource(actor, ability).updateOptions(config);
+    new AbilityCheckReminder(actor, ability).updateOptions(config);
   }
 
   preRollDeathSave(actor, config) {

--- a/src/rollers/midi.js
+++ b/src/rollers/midi.js
@@ -59,8 +59,9 @@ export default class MidiRollerHooks extends CoreRollerHooks {
 
     if (this.isFastForwarding(config)) return;
 
-    new SkillMessage(actor, skillId).addMessage(config);
-    if (showSources) new SkillSource(actor, skillId, true).updateOptions(config);
+    const ability = config.data.defaultAbility;
+    new SkillMessage(actor, ability, skillId).addMessage(config);
+    if (showSources) new SkillSource(actor, ability, skillId, true).updateOptions(config);
   }
 
   preRollToolCheck(actor, config, toolId) {

--- a/src/rollers/midi.js
+++ b/src/rollers/midi.js
@@ -63,13 +63,14 @@ export default class MidiRollerHooks extends CoreRollerHooks {
     if (showSources) new SkillSource(actor, skillId, true).updateOptions(config);
   }
 
-  preRollToolCheck(item, config) {
+  preRollToolCheck(actor, config, toolId) {
     debug("preRollToolCheck hook called");
 
     if (this.isFastForwarding(config)) return;
 
-    new AbilityCheckMessage(item.actor, item.system.ability).addMessage(config);
-    if (showSources) new AbilityCheckSource(item.actor, item.system.ability).updateOptions(config);
+    const ability = config.data.defaultAbility;
+    new AbilityCheckMessage(actor, ability).addMessage(config);
+    if (showSources) new AbilityCheckSource(actor, ability).updateOptions(config);
   }
 
   preRollDeathSave(actor, config) {

--- a/src/rollers/rsr.js
+++ b/src/rollers/rsr.js
@@ -92,17 +92,18 @@ export default class ReadySetRollHooks extends CoreRollerHooks {
       new SkillReminder(actor, skillId, this.checkArmorStealth).updateOptions(config);
   }
 
-  preRollToolCheck(item, config) {
+  preRollToolCheck(actor, config, toolId) {
     debug("preRollToolCheck hook called");
 
+    const ability = config.data.defaultAbility;
     if (this._doMessages(config)) {
-      new AbilityCheckMessage(item.actor, item.system.ability).addMessage(config);
+      new AbilityCheckMessage(actor, ability).addMessage(config);
       if (showSources)
-        new AbilityCheckSource(item.actor, item.system.ability).updateOptions(config);
+        new AbilityCheckSource(actor, ability).updateOptions(config);
     }
 
     if (this._doReminder(config))
-      new AbilityCheckReminder(item.actor, item.system.ability).updateOptions(config);
+      new AbilityCheckReminder(actor, ability).updateOptions(config);
   }
 
   preRollDeathSave(actor, config) {

--- a/src/rollers/rsr.js
+++ b/src/rollers/rsr.js
@@ -83,13 +83,14 @@ export default class ReadySetRollHooks extends CoreRollerHooks {
   preRollSkill(actor, config, skillId) {
     debug("preRollSkill hook called");
 
+    const ability = config.data.defaultAbility;
     if (this._doMessages(config)) {
-      new SkillMessage(actor, skillId).addMessage(config);
-      if (showSources) new SkillSource(actor, skillId, true).updateOptions(config);
+      new SkillMessage(actor, ability, skillId).addMessage(config);
+      if (showSources) new SkillSource(actor, ability, skillId, true).updateOptions(config);
     }
 
     if (this._doReminder(config))
-      new SkillReminder(actor, skillId, this.checkArmorStealth).updateOptions(config);
+      new SkillReminder(actor, ability, skillId, this.checkArmorStealth).updateOptions(config);
   }
 
   preRollToolCheck(actor, config, toolId) {

--- a/test/common.js
+++ b/test/common.js
@@ -3,64 +3,6 @@ export default function commonTestInit() {
 
   globalThis.createActorWithFlags = (...keys) => {
     const actor = {
-      system: {
-        skills: {
-          acr: {
-            ability: "dex",
-          },
-          ani: {
-            ability: "wis",
-          },
-          arc: {
-            ability: "int",
-          },
-          ath: {
-            ability: "str",
-          },
-          dec: {
-            ability: "cha",
-          },
-          his: {
-            ability: "int",
-          },
-          ins: {
-            ability: "wis",
-          },
-          itm: {
-            ability: "cha",
-          },
-          inv: {
-            ability: "int",
-          },
-          med: {
-            ability: "wis",
-          },
-          nat: {
-            ability: "int",
-          },
-          prc: {
-            ability: "wis",
-          },
-          prf: {
-            ability: "cha",
-          },
-          per: {
-            ability: "cha",
-          },
-          rel: {
-            ability: "int",
-          },
-          slt: {
-            ability: "dex",
-          },
-          ste: {
-            ability: "dex",
-          },
-          sur: {
-            ability: "wis",
-          },
-        },
-      },
       flags: {},
     };
     keys.forEach((k) => setProperty(actor, k, true));

--- a/test/messages.test.js
+++ b/test/messages.test.js
@@ -25,64 +25,6 @@ globalThis.setProperty = (object, key, value) => {
 function createActorWithEffects(...keyValuePairs) {
   const appliedEffects = keyValuePairs.map(createEffect);
   return {
-    system: {
-      skills: {
-        acr: {
-          ability: "dex",
-        },
-        ani: {
-          ability: "wis",
-        },
-        arc: {
-          ability: "int",
-        },
-        ath: {
-          ability: "str",
-        },
-        dec: {
-          ability: "cha",
-        },
-        his: {
-          ability: "int",
-        },
-        ins: {
-          ability: "wis",
-        },
-        itm: {
-          ability: "cha",
-        },
-        inv: {
-          ability: "int",
-        },
-        med: {
-          ability: "wis",
-        },
-        nat: {
-          ability: "int",
-        },
-        prc: {
-          ability: "wis",
-        },
-        prf: {
-          ability: "cha",
-        },
-        per: {
-          ability: "cha",
-        },
-        rel: {
-          ability: "int",
-        },
-        slt: {
-          ability: "dex",
-        },
-        ste: {
-          ability: "dex",
-        },
-        sur: {
-          ability: "wis",
-        },
-      },
-    },
     appliedEffects,
     getRollData: () => ({}),
   };
@@ -491,7 +433,7 @@ describe("SkillMessage no legit active effects", () => {
     const actor = createActorWithEffects();
     const options = {};
 
-    new SkillMessage(actor, "ath").addMessage(options);
+    new SkillMessage(actor, "str", "ath").addMessage(options);
 
     expect(options.dialogOptions).toBeUndefined();
   });
@@ -502,7 +444,7 @@ describe("SkillMessage message flags", () => {
     const actor = createActorWithEffects(["flags.adv-reminder.message.all", "message.all message"]);
     const options = {};
 
-    new SkillMessage(actor, "prc").addMessage(options);
+    new SkillMessage(actor, "wis", "prc").addMessage(options);
 
     expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual(["message.all message"]);
   });
@@ -514,7 +456,7 @@ describe("SkillMessage message flags", () => {
     ]);
     const options = {};
 
-    new SkillMessage(actor, "prc").addMessage(options);
+    new SkillMessage(actor, "wis", "prc").addMessage(options);
 
     expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual([
       "message.ability.all message",
@@ -528,7 +470,7 @@ describe("SkillMessage message flags", () => {
     ]);
     const options = {};
 
-    new SkillMessage(actor, "prc").addMessage(options);
+    new SkillMessage(actor, "wis", "prc").addMessage(options);
 
     expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual([
       "message.ability.check.all message",
@@ -542,7 +484,7 @@ describe("SkillMessage message flags", () => {
     ]);
     const options = {};
 
-    new SkillMessage(actor, "prc").addMessage(options);
+    new SkillMessage(actor, "wis", "prc").addMessage(options);
 
     expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual([
       "message.ability.check.int message",
@@ -556,7 +498,7 @@ describe("SkillMessage message flags", () => {
     ]);
     const options = {};
 
-    new SkillMessage(actor, "acr").addMessage(options);
+    new SkillMessage(actor, "dex", "acr").addMessage(options);
 
     expect(options.dialogOptions).toBeUndefined();
   });
@@ -568,7 +510,7 @@ describe("SkillMessage message flags", () => {
     ]);
     const options = {};
 
-    new SkillMessage(actor, "prc").addMessage(options);
+    new SkillMessage(actor, "wis", "prc").addMessage(options);
 
     expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual([
       "message.skill.all message",
@@ -582,7 +524,7 @@ describe("SkillMessage message flags", () => {
     ]);
     const options = {};
 
-    new SkillMessage(actor, "prc").addMessage(options);
+    new SkillMessage(actor, "wis", "prc").addMessage(options);
 
     expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual([
       "message.skill.prc message",
@@ -596,7 +538,7 @@ describe("SkillMessage message flags", () => {
     ]);
     const options = {};
 
-    new SkillMessage(actor, "nat").addMessage(options);
+    new SkillMessage(actor, "int", "nat").addMessage(options);
 
     expect(options.dialogOptions).toBeUndefined();
   });
@@ -608,7 +550,7 @@ describe("SkillMessage message flags", () => {
     );
     const options = {};
 
-    new SkillMessage(actor, "ste").addMessage(options);
+    new SkillMessage(actor, "dex", "ste").addMessage(options);
 
     expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual(["first", "second"]);
   });

--- a/test/reminders.test.js
+++ b/test/reminders.test.js
@@ -654,7 +654,7 @@ describe("SkillReminder no legit active effects", () => {
     const actor = createActorWithFlags();
     const options = {};
 
-    const reminder = new SkillReminder(actor, "prc");
+    const reminder = new SkillReminder(actor, "wis", "prc");
     reminder.updateOptions(options);
 
     expect(options.advantage).toBeUndefined();
@@ -675,7 +675,7 @@ describe("SkillReminder no legit active effects", () => {
     ];
     const options = {};
 
-    const reminder = new SkillReminder(actor, "ste");
+    const reminder = new SkillReminder(actor, "dex", "ste");
     reminder.updateOptions(options);
 
     expect(options.advantage).toBeUndefined();
@@ -696,7 +696,7 @@ describe("SkillReminder no legit active effects", () => {
     ];
     const options = {};
 
-    const reminder = new SkillReminder(actor, "ste");
+    const reminder = new SkillReminder(actor, "dex", "ste");
     reminder.updateOptions(options);
 
     expect(options.advantage).toBeUndefined();
@@ -709,7 +709,7 @@ describe("SkillReminder advantage flags", () => {
     const actor = createActorWithFlags("flags.midi-qol.advantage.all");
     const options = {};
 
-    const reminder = new SkillReminder(actor, "prc");
+    const reminder = new SkillReminder(actor, "wis", "prc");
     reminder.updateOptions(options);
 
     expect(options.advantage).toBe(true);
@@ -720,7 +720,7 @@ describe("SkillReminder advantage flags", () => {
     const actor = createActorWithFlags("flags.midi-qol.advantage.ability.all");
     const options = {};
 
-    const reminder = new SkillReminder(actor, "prc");
+    const reminder = new SkillReminder(actor, "wis", "prc");
     reminder.updateOptions(options);
 
     expect(options.advantage).toBe(true);
@@ -731,7 +731,7 @@ describe("SkillReminder advantage flags", () => {
     const actor = createActorWithFlags("flags.midi-qol.advantage.ability.check.all");
     const options = {};
 
-    const reminder = new SkillReminder(actor, "prc");
+    const reminder = new SkillReminder(actor, "wis", "prc");
     reminder.updateOptions(options);
 
     expect(options.advantage).toBe(true);
@@ -742,7 +742,7 @@ describe("SkillReminder advantage flags", () => {
     const actor = createActorWithFlags("flags.midi-qol.advantage.ability.check.wis");
     const options = {};
 
-    const reminder = new SkillReminder(actor, "prc");
+    const reminder = new SkillReminder(actor, "wis", "prc");
     reminder.updateOptions(options);
 
     expect(options.advantage).toBe(true);
@@ -753,7 +753,7 @@ describe("SkillReminder advantage flags", () => {
     const actor = createActorWithFlags("flags.midi-qol.advantage.ability.check.wis");
     const options = {};
 
-    const reminder = new SkillReminder(actor, "arc");
+    const reminder = new SkillReminder(actor, "int", "arc");
     reminder.updateOptions(options);
 
     expect(options.advantage).toBeUndefined();
@@ -764,7 +764,7 @@ describe("SkillReminder advantage flags", () => {
     const actor = createActorWithFlags("flags.midi-qol.advantage.skill.all");
     const options = {};
 
-    const reminder = new SkillReminder(actor, "prc");
+    const reminder = new SkillReminder(actor, "wis", "prc");
     reminder.updateOptions(options);
 
     expect(options.advantage).toBe(true);
@@ -775,7 +775,7 @@ describe("SkillReminder advantage flags", () => {
     const actor = createActorWithFlags("flags.midi-qol.advantage.skill.prc");
     const options = {};
 
-    const reminder = new SkillReminder(actor, "prc");
+    const reminder = new SkillReminder(actor, "wis", "prc");
     reminder.updateOptions(options);
 
     expect(options.advantage).toBe(true);
@@ -786,7 +786,7 @@ describe("SkillReminder advantage flags", () => {
     const actor = createActorWithFlags("flags.midi-qol.advantage.skill.prc");
     const options = {};
 
-    const reminder = new SkillReminder(actor, "arc");
+    const reminder = new SkillReminder(actor, "int", "arc");
     reminder.updateOptions(options);
 
     expect(options.advantage).toBeUndefined();
@@ -799,7 +799,7 @@ describe("SkillReminder disadvantage flags", () => {
     const actor = createActorWithFlags("flags.midi-qol.disadvantage.all");
     const options = {};
 
-    const reminder = new SkillReminder(actor, "prc");
+    const reminder = new SkillReminder(actor, "wis", "prc");
     reminder.updateOptions(options);
 
     expect(options.advantage).toBeUndefined();
@@ -810,7 +810,7 @@ describe("SkillReminder disadvantage flags", () => {
     const actor = createActorWithFlags("flags.midi-qol.disadvantage.ability.all");
     const options = {};
 
-    const reminder = new SkillReminder(actor, "prc");
+    const reminder = new SkillReminder(actor, "wis", "prc");
     reminder.updateOptions(options);
 
     expect(options.advantage).toBeUndefined();
@@ -821,7 +821,7 @@ describe("SkillReminder disadvantage flags", () => {
     const actor = createActorWithFlags("flags.midi-qol.disadvantage.ability.check.all");
     const options = {};
 
-    const reminder = new SkillReminder(actor, "prc");
+    const reminder = new SkillReminder(actor, "wis", "prc");
     reminder.updateOptions(options);
 
     expect(options.advantage).toBeUndefined();
@@ -832,7 +832,7 @@ describe("SkillReminder disadvantage flags", () => {
     const actor = createActorWithFlags("flags.midi-qol.disadvantage.ability.check.wis");
     const options = {};
 
-    const reminder = new SkillReminder(actor, "prc");
+    const reminder = new SkillReminder(actor, "wis", "prc");
     reminder.updateOptions(options);
 
     expect(options.advantage).toBeUndefined();
@@ -843,7 +843,7 @@ describe("SkillReminder disadvantage flags", () => {
     const actor = createActorWithFlags("flags.midi-qol.disadvantage.ability.check.wis");
     const options = {};
 
-    const reminder = new SkillReminder(actor, "arc");
+    const reminder = new SkillReminder(actor, "int", "arc");
     reminder.updateOptions(options);
 
     expect(options.advantage).toBeUndefined();
@@ -854,7 +854,7 @@ describe("SkillReminder disadvantage flags", () => {
     const actor = createActorWithFlags("flags.midi-qol.disadvantage.skill.all");
     const options = {};
 
-    const reminder = new SkillReminder(actor, "prc");
+    const reminder = new SkillReminder(actor, "wis", "prc");
     reminder.updateOptions(options);
 
     expect(options.advantage).toBeUndefined();
@@ -865,7 +865,7 @@ describe("SkillReminder disadvantage flags", () => {
     const actor = createActorWithFlags("flags.midi-qol.disadvantage.skill.prc");
     const options = {};
 
-    const reminder = new SkillReminder(actor, "prc");
+    const reminder = new SkillReminder(actor, "wis", "prc");
     reminder.updateOptions(options);
 
     expect(options.advantage).toBeUndefined();
@@ -876,7 +876,7 @@ describe("SkillReminder disadvantage flags", () => {
     const actor = createActorWithFlags("flags.midi-qol.disadvantage.skill.prc");
     const options = {};
 
-    const reminder = new SkillReminder(actor, "arc");
+    const reminder = new SkillReminder(actor, "int", "arc");
     reminder.updateOptions(options);
 
     expect(options.advantage).toBeUndefined();
@@ -897,7 +897,7 @@ describe("SkillReminder disadvantage flags", () => {
     ];
     const options = {};
 
-    const reminder = new SkillReminder(actor, "ste");
+    const reminder = new SkillReminder(actor, "dex", "ste");
     reminder.updateOptions(options);
 
     expect(options.advantage).toBeUndefined();
@@ -918,7 +918,7 @@ describe("SkillReminder disadvantage flags", () => {
     ];
     const options = {};
 
-    const reminder = new SkillReminder(actor, "ste", false);
+    const reminder = new SkillReminder(actor, "dex", "ste", false);
     reminder.updateOptions(options);
 
     expect(options.advantage).toBeUndefined();
@@ -934,7 +934,7 @@ describe("SkillReminder both advantage and disadvantage flags", () => {
     );
     const options = {};
 
-    const reminder = new SkillReminder(actor, "prc");
+    const reminder = new SkillReminder(actor, "wis", "prc");
     reminder.updateOptions(options);
 
     expect(options.advantage).toBeUndefined();
@@ -948,7 +948,7 @@ describe("SkillReminder both advantage and disadvantage flags", () => {
     );
     const options = {};
 
-    const reminder = new SkillReminder(actor, "prc");
+    const reminder = new SkillReminder(actor, "wis", "prc");
     reminder.updateOptions(options);
 
     expect(options.advantage).toBeUndefined();
@@ -962,7 +962,7 @@ describe("SkillReminder both advantage and disadvantage flags", () => {
     );
     const options = {};
 
-    const reminder = new SkillReminder(actor, "prc");
+    const reminder = new SkillReminder(actor, "wis", "prc");
     reminder.updateOptions(options);
 
     expect(options.advantage).toBe(true);


### PR DESCRIPTION
Way back in dnd5e 2.2.0, they moved tool checks from the item to the actor. When doing so, the `dnd5e.preRollToolCheck` hook changed its arguments. Now we can get the `toolId` but Midi hasn't defined any new flags that use that so I'm not going to add it here. But it does now pass the ability used in `config.data.defaultAbility` so I don't need to look it up on the actor. It also honors the ability they may have passed in as an argument to the `rollToolCheck` function.

While here, I noticed skills use the same `config.data.defaultAbility` which also honors the ability that is passed into `rollSkill`. While an edge case, it could come up more often now that the enrichers exist to prompt for skill checks where you can specify the ability as well.