### PR TITLE
Update the system-defined status effects to include advantage/disadvantage flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.4.0
+
+- feature: Update the system-defined status effects to include advantage/disadvantage flags. Controlled by a setting.
+
 # 3.3.2
 
 - bug fix: [#60](https://github.com/kaelad02/adv-reminder/issues/60) Fix tool checks to show advantage and messages again after the check was moved from the item to the actor

--- a/lang/en.json
+++ b/lang/en.json
@@ -27,5 +27,9 @@
     "Dis": "Disadvantage from {sources}",
     "Crit": "Critical Hit from {sources}",
     "Norm": "Normal from {sources}"
+  },
+  "adv-reminder.UpdateStatusEffects": {
+    "Name": "Update Status Effects",
+    "Hint": "Update the status effects that the system adds to include the appropriate advantage/disadvantage flags. Not recommended if you are using another module to modify or replace them."
   }
 }

--- a/module.json
+++ b/module.json
@@ -14,7 +14,7 @@
         "id": "dnd5e",
         "compatibility": {
           "minimum": "3.0.0",
-          "verified": "3.0.0"
+          "verified": "3.0.3"
         }
       },
       {

--- a/src/module.js
+++ b/src/module.js
@@ -40,10 +40,11 @@ function applyMidiCustom(actor, change) {
 }
 
 Hooks.once("setup", () => {
-  // TODO guard with a setting
-  updateStatusEffects();
-  Hooks.on("preCreateActiveEffect", addExhaustionEffects);
-  Hooks.on("preUpdateActiveEffect", addExhaustionEffects);
+  if (game.settings.get("adv-reminder", "updateStatusEffects")) {
+    updateStatusEffects();
+    Hooks.on("preCreateActiveEffect", addExhaustionEffects);
+    Hooks.on("preUpdateActiveEffect", addExhaustionEffects);
+  }
 });
 
 function updateStatusEffects() {
@@ -353,8 +354,7 @@ Hooks.once("DAE.setupComplete", () => {
   fields.push("flags.adv-reminder.message.deathSave");
   fields.push("flags.adv-reminder.message.damage.all");
 
-  const actionTypes =
-    game.system.id === "sw5e" ? ["mwak", "rwak", "mpak", "rpak"] : ["mwak", "rwak", "msak", "rsak"];
+  const actionTypes = game.system.id === "sw5e" ? ["mwak", "rwak", "mpak", "rpak"] : ["mwak", "rwak", "msak", "rsak"];
   actionTypes.forEach((actionType) => fields.push(`flags.adv-reminder.message.attack.${actionType}`));
 
   Object.keys(CONFIG.DND5E.itemActionTypes).forEach((actionType) =>
@@ -367,9 +367,7 @@ Hooks.once("DAE.setupComplete", () => {
     fields.push(`flags.adv-reminder.message.ability.save.${abilityId}`);
   });
 
-  Object.keys(CONFIG.DND5E.skills).forEach((skillId) =>
-    fields.push(`flags.adv-reminder.message.skill.${skillId}`)
-  );
+  Object.keys(CONFIG.DND5E.skills).forEach((skillId) => fields.push(`flags.adv-reminder.message.skill.${skillId}`));
 
   window.DAE.addAutoFields(fields);
 });
@@ -432,10 +430,7 @@ async function prepareMessage(dialogOptions) {
 
   if (messages.length) {
     // build message
-    const message = await renderTemplate(
-      "modules/adv-reminder/templates/roll-dialog-messages.hbs",
-      { messages }
-    );
+    const message = await renderTemplate("modules/adv-reminder/templates/roll-dialog-messages.hbs", { messages });
     // enrich message, specifically replacing rolls
     const enriched = await TextEditor.enrichHTML(message, {
       secrets: true,

--- a/src/module.js
+++ b/src/module.js
@@ -49,6 +49,7 @@ Hooks.once("setup", () => {
 
 function updateStatusEffects() {
   debug("updateStatusEffects");
+
   const effectChanges = {
     blinded: {
       changes: [
@@ -83,7 +84,6 @@ function updateStatusEffects() {
         },
       ],
     },
-    // TODO exhaustion
     frightened: {
       changes: [
         {
@@ -167,27 +167,6 @@ function updateStatusEffects() {
           mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
           value: "1",
         },
-        /* {
-          key: "system.traits.di.value",
-          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
-          value: "poison",
-        },
-        {
-          key: "system.traits.dr.all",
-          mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
-          value: "physical",
-        },
-        {
-          key: "system.traits.dr.all",
-          mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
-          value: "magical",
-        },
-        {
-          key: "system.attributes.movement.all",
-          mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
-          value: "0",
-          priority: 25,
-        }, */
       ],
     },
     poisoned: {
@@ -293,8 +272,6 @@ function updateStatusEffects() {
           mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
           value: "5",
         },
-        // TODO does prone already get applied?
-        //...this._prone.changes,
       ],
     },
   };
@@ -306,7 +283,8 @@ function updateStatusEffects() {
 }
 
 function addExhaustionEffects(effect, updates) {
-  debug("addExhaustionEffects", effect, updates);
+  debug("addExhaustionEffects");
+
   if (effect.id !== dnd5e.documents.ActiveEffect5e.ID.EXHAUSTION) return;
   const level = foundry.utils.getProperty(updates, "flags.dnd5e.exhaustionLevel");
   if (!level) return;

--- a/src/module.js
+++ b/src/module.js
@@ -39,6 +39,269 @@ function applyMidiCustom(actor, change) {
   }
 }
 
+Hooks.once("setup", () => {
+  // TODO guard with a setting
+  updateStatusEffects();
+});
+
+function updateStatusEffects() {
+  debug("updateStatusEffects");
+  const effectChanges = {
+    blinded: {
+      changes: [
+        {
+          key: "flags.midi-qol.disadvantage.attack.all",
+          mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+          value: "1",
+        },
+        {
+          key: "flags.midi-qol.grants.advantage.attack.all",
+          mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+          value: "1",
+        },
+      ],
+    },
+    dodging: {
+      flags: {
+        dae: {
+          specialDuration: ["turnStart"],
+        },
+      },
+      changes: [
+        {
+          key: "flags.midi-qol.grants.disadvantage.attack.all",
+          mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+          value: "1",
+        },
+        {
+          key: "flags.midi-qol.advantage.ability.save.dex",
+          mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+          value: "1",
+        },
+      ],
+    },
+    // TODO exhaustion
+    frightened: {
+      changes: [
+        {
+          key: "flags.midi-qol.disadvantage.attack.all",
+          mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+          value: "1",
+        },
+        {
+          key: "flags.midi-qol.disadvantage.ability.check.all",
+          mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+          value: "1",
+        },
+      ],
+    },
+    hidden: {
+      changes: [
+        {
+          key: "flags.midi-qol.advantage.attack.all",
+          mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+          value: "1",
+        },
+        {
+          key: "flags.midi-qol.grants.disadvantage.attack.all",
+          mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+          value: "1",
+        },
+      ],
+    },
+    invisible: {
+      changes: [
+        {
+          key: "flags.midi-qol.advantage.attack.all",
+          mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+          value: "1",
+        },
+        {
+          key: "flags.midi-qol.grants.disadvantage.attack.all",
+          mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+          value: "1",
+        },
+      ],
+    },
+    paralyzed: {
+      changes: [
+        {
+          key: "flags.midi-qol.fail.ability.save.dex",
+          mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+          value: "1",
+        },
+        {
+          key: "flags.midi-qol.fail.ability.save.str",
+          mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+          value: "1",
+        },
+        {
+          key: "flags.midi-qol.grants.advantage.attack.all",
+          mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+          value: "1",
+        },
+        {
+          key: "flags.midi-qol.grants.critical.range",
+          mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
+          value: "5",
+        },
+      ],
+    },
+    petrified: {
+      changes: [
+        {
+          key: "flags.midi-qol.grants.advantage.attack.all",
+          mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+          value: "1",
+        },
+        {
+          key: "flags.midi-qol.fail.ability.save.dex",
+          mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+          value: "1",
+        },
+        {
+          key: "flags.midi-qol.fail.ability.save.str",
+          mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+          value: "1",
+        },
+        /* {
+          key: "system.traits.di.value",
+          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+          value: "poison",
+        },
+        {
+          key: "system.traits.dr.all",
+          mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+          value: "physical",
+        },
+        {
+          key: "system.traits.dr.all",
+          mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+          value: "magical",
+        },
+        {
+          key: "system.attributes.movement.all",
+          mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+          value: "0",
+          priority: 25,
+        }, */
+      ],
+    },
+    poisoned: {
+      changes: [
+        {
+          key: "flags.midi-qol.disadvantage.attack.all",
+          mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+          value: "1",
+        },
+        {
+          key: "flags.midi-qol.disadvantage.ability.check.all",
+          mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+          value: "1",
+        },
+      ],
+    },
+    prone: {
+      changes: [
+        {
+          key: "flags.midi-qol.grants.advantage.attack.mwak",
+          mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+          value: "1",
+        },
+        {
+          key: "flags.midi-qol.grants.advantage.attack.msak",
+          mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+          value: "1",
+        },
+        {
+          key: "flags.midi-qol.grants.disadvantage.attack.rwak",
+          mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+          value: "1",
+        },
+        {
+          key: "flags.midi-qol.grants.disadvantage.attack.rsak",
+          mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+          value: "1",
+        },
+        {
+          key: "flags.midi-qol.disadvantage.attack.all",
+          mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+          value: "1",
+        },
+      ],
+    },
+    restrained: {
+      changes: [
+        {
+          key: "flags.midi-qol.disadvantage.ability.save.dex",
+          mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+          value: "1",
+        },
+        {
+          key: "flags.midi-qol.disadvantage.attack.all",
+          mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+          value: "1",
+        },
+        {
+          key: "flags.midi-qol.grants.advantage.attack.all",
+          mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+          value: "1",
+        },
+      ],
+    },
+    stunned: {
+      changes: [
+        {
+          key: "flags.midi-qol.fail.ability.save.dex",
+          mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+          value: "1",
+        },
+        {
+          key: "flags.midi-qol.fail.ability.save.str",
+          mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+          value: "1",
+        },
+        {
+          key: "flags.midi-qol.grants.advantage.attack.all",
+          mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+          value: "1",
+        },
+      ],
+    },
+    unconscious: {
+      changes: [
+        {
+          key: "flags.midi-qol.fail.ability.save.dex",
+          mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+          value: "1",
+        },
+        {
+          key: "flags.midi-qol.fail.ability.save.str",
+          mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+          value: "1",
+        },
+        {
+          key: "flags.midi-qol.grants.advantage.attack.all",
+          mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+          value: "1",
+        },
+        {
+          key: "flags.midi-qol.grants.critical.range",
+          mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
+          value: "5",
+        },
+        // TODO does prone already get applied?
+        //...this._prone.changes,
+      ],
+    },
+  };
+
+  Object.entries(effectChanges).forEach(([id, data]) => {
+    const effect = CONFIG.statusEffects.find((e) => e.id === id);
+    if (effect) foundry.utils.mergeObject(effect, data);
+  });
+}
+
 // Add message flags to DAE so it shows them in the AE editor
 Hooks.once("DAE.setupComplete", () => {
   debug("adding Advantage Reminder flags to DAE");

--- a/src/reminders.js
+++ b/src/reminders.js
@@ -1,4 +1,4 @@
-import { debug } from "./util.js";
+import { debug, isEmpty } from "./util.js";
 
 class BaseReminder {
   constructor(actor) {
@@ -61,7 +61,7 @@ export class AttackReminder extends BaseReminder {
     this._message();
 
     // quick return if there are no flags
-    if (this.actorFlags === {} && this.targetFlags === {}) return;
+    if (isEmpty(this.actorFlags) && isEmpty(this.targetFlags)) return;
 
     // build the active effect keys applicable for this roll
     const advKeys = [
@@ -113,7 +113,7 @@ class AbilityBaseReminder extends BaseReminder {
     this._message();
 
     // quick return if there are no flags
-    if (this.actorFlags === {}) return;
+    if (isEmpty(this.actorFlags)) return;
 
     // get the active effect keys applicable for this roll
     const advKeys = this.advantageKeys;
@@ -254,7 +254,7 @@ export class CriticalReminder extends BaseReminder {
     this._message();
 
     // quick return if there are no flags
-    if (this.actorFlags === {} && this.targetFlags === {}) return;
+    if (isEmpty(this.actorFlags) && isEmpty(this.targetFlags)) return;
 
     // build the active effect keys applicable for this roll
     const critKeys = ["critical.all", `critical.${this.actionType}`];

--- a/src/settings.js
+++ b/src/settings.js
@@ -54,6 +54,16 @@ Hooks.once("init", () => {
     default: true,
     onChange: (value) => (showSources = value),
   });
+
+  game.settings.register("adv-reminder", "updateStatusEffects", {
+    name: "adv-reminder.UpdateStatusEffects.Name",
+    hint: "adv-reminder.UpdateStatusEffects.Hint",
+    scope: "world",
+    config: true,
+    requiresReload: true,
+    type: Boolean,
+    default: false,
+  });
 });
 
 Hooks.once("ready", () => {

--- a/src/util.js
+++ b/src/util.js
@@ -28,3 +28,12 @@ export function isMinVersion(name, version) {
 export function getTarget() {
   return [...game.user.targets][0]?.actor;
 }
+
+/**
+ * Test if an object is empty.
+ * @param {object} obj object to test
+ * @returns true if an object is empty, false otherwise
+ */
+export function isEmpty(obj) {
+  return !Object.keys(obj).length;
+}


### PR DESCRIPTION
- uses an un-implemented flag, `grants.critical.range`
- cleans up some errors VSCode pointed out about checking for empty objects
- updated verified system version since that's what I developed on