### PR TITLE
Support the grants.critical.range flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # upcoming
 
-- feature: Support the system's new concentration rolls with sources and messages (system already handles advantage/disadvantage)
+- feature: Support the system's new concentration rolls with sources and messages with `flags.adv-reminder.message.ability.concentration` (system already handles advantage/disadvantage)
 - feature: Support `flags.midi-qol.grants.critical.range` for conditions like Paralyzed that turn hits into crits if the attacker is adjacent. Does not currently work with Ready Set Roll, will just be ignored.
 
 # 3.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# upcoming
+
+- feature: Support `flags.midi-qol.grants.critical.range` for conditions like Paralyzed that turn hits into crits if the attacker is adjacent. Does not currently work with Ready Set Roll, will just be ignored.
+
 # 3.4.1
 
 - feature: [#64](https://github.com/kaelad02/adv-reminder/pull/64) Add pt-BR translation, thanks @Kharmans

--- a/src/reminders.js
+++ b/src/reminders.js
@@ -260,8 +260,11 @@ export class CriticalReminder extends BaseReminder {
     this.actionType = item.system.actionType;
 
     // get the Range directly from the actor's flags
-    const grantsCriticalRange = getProperty(targetActor, "flags.midi-qol.grants.critical.range") || -Infinity;
-    this._adjustRange(distanceFn, grantsCriticalRange);
+    if (targetActor) {
+      const grantsCriticalRange =
+        getProperty(targetActor, "flags.midi-qol.grants.critical.range") || -Infinity;
+      this._adjustRange(distanceFn, grantsCriticalRange);
+    }
   }
 
   _adjustRange(distanceFn, grantsCriticalRange) {

--- a/src/reminders.js
+++ b/src/reminders.js
@@ -250,15 +250,15 @@ export class CriticalReminder extends BaseReminder {
     this.actionType = item.system.actionType;
 
     // get the Range directly from the actor's flags
-    this.grantsCriticalRange = targetActor?.flags["midi-qol"].grants.critical.range || -Infinity;
-    this._adjustRange(distanceFn);
+    const grantsCriticalRange = getProperty(targetActor, "flags.midi-qol.grants.critical.range") || -Infinity;
+    this._adjustRange(distanceFn, grantsCriticalRange);
   }
 
-  _adjustRange(distanceFn) {
+  _adjustRange(distanceFn, grantsCriticalRange) {
     // adjust the Range flag to look like a boolean like the rest
     if ("grants.critical.range" in this.targetFlags) {
       const distance = distanceFn();
-      this.targetFlags["grants.critical.range"] = distance <= this.grantsCriticalRange;
+      this.targetFlags["grants.critical.range"] = distance <= grantsCriticalRange;
     }
   }
 

--- a/src/rollers/core.js
+++ b/src/rollers/core.js
@@ -24,7 +24,7 @@ import {
   SkillSource,
 } from "../sources.js";
 import { showSources } from "../settings.js";
-import { debug, getTarget } from "../util.js";
+import { debug, getDistanceToTargetFn, getTarget } from "../util.js";
 
 /**
  * Setup the dnd5e.preRoll hooks for use with the core roller.
@@ -133,10 +133,11 @@ export default class CoreRollerHooks {
 
     if (this.isFastForwarding(config)) return;
     const target = getTarget();
+    const distanceFn = getDistanceToTargetFn(config.messageData.speaker);
 
     new DamageMessage(item.actor, target, item).addMessage(config);
-    if (showSources) new CriticalSource(item.actor, target, item).updateOptions(config);
-    new CriticalReminder(item.actor, target, item).updateOptions(config);
+    if (showSources) new CriticalSource(item.actor, target, item, distanceFn).updateOptions(config);
+    new CriticalReminder(item.actor, target, item, distanceFn).updateOptions(config);
   }
 
   /**

--- a/src/rollers/midi.js
+++ b/src/rollers/midi.js
@@ -88,8 +88,15 @@ export default class MidiRollerHooks extends CoreRollerHooks {
 
     if (this.isFastForwarding(config)) return;
     const target = getTarget();
+    // use distance from Midi's Workflow
+    const distanceFn = () => {
+      const workflow = MidiQOL.Workflow.getWorkflow(item.uuid);
+      if (!workflow) return Infinity;
+      const firstTarget = workflow.hitTargets.values().next().value;
+      return MidiQOL.computeDistance(firstTarget, workflow.token, false);
+    }
 
     new DamageMessage(item.actor, target, item).addMessage(config);
-    if (showSources) new CriticalSource(item.actor, target, item).updateOptions(config);
+    if (showSources) new CriticalSource(item.actor, target, item, distanceFn).updateOptions(config);
   }
 }

--- a/src/rollers/rsr.js
+++ b/src/rollers/rsr.js
@@ -27,6 +27,10 @@ import { showSources } from "../settings.js";
 import { debug, getTarget } from "../util.js";
 import CoreRollerHooks from "./core.js";
 
+// disable the grants.critical.range flag since RSR can't have it's critical flag changed anyways,
+// only set by the attack roll
+const distanceFn = () => Infinity;
+
 /**
  * Setup the dnd5e.preRoll hooks for use with Ready Set Roll.
  */
@@ -125,7 +129,7 @@ export default class ReadySetRollHooks extends CoreRollerHooks {
 
     if (this._doMessages(config)) {
       new DamageMessage(item.actor, target, item).addMessage(config);
-      if (showSources) new CriticalSource(item.actor, target, item).updateOptions(config);
+      if (showSources) new CriticalSource(item.actor, target, item, distanceFn).updateOptions(config);
     }
     // don't use CriticalReminder here, it's done in another hook
   }
@@ -135,7 +139,7 @@ export default class ReadySetRollHooks extends CoreRollerHooks {
 
     // check for critical hits but set the "isCrit" property instead of the default "critical"
     const target = getTarget();
-    new CriticalReminder(item.actor, target, item).updateOptions(config, "isCrit");
+    new CriticalReminder(item.actor, target, item, distanceFn).updateOptions(config, "isCrit");
   }
 
   _doMessages({ fastForward = false }) {

--- a/src/sources.js
+++ b/src/sources.js
@@ -77,6 +77,14 @@ export class SkillSource extends SourceMixin(SkillReminder) {}
 export class DeathSaveSource extends SourceMixin(DeathSaveReminder) {}
 
 export class CriticalSource extends SourceMixin(CriticalReminder) {
+  _adjustRange(distanceFn) {
+    // check if the range applies, remove flag if not
+    if ("grants.critical.range" in this.targetFlags) {
+      const distance = distanceFn();
+      if (distance > this.grantsCriticalRange) delete this.targetFlags["grants.critical.range"];
+    }
+  }
+
   _accumulator() {
     const criticalLabels = [];
     const normalLabels = [];

--- a/src/sources.js
+++ b/src/sources.js
@@ -77,11 +77,11 @@ export class SkillSource extends SourceMixin(SkillReminder) {}
 export class DeathSaveSource extends SourceMixin(DeathSaveReminder) {}
 
 export class CriticalSource extends SourceMixin(CriticalReminder) {
-  _adjustRange(distanceFn) {
+  _adjustRange(distanceFn, grantsCriticalRange) {
     // check if the range applies, remove flag if not
     if ("grants.critical.range" in this.targetFlags) {
       const distance = distanceFn();
-      if (distance > this.grantsCriticalRange) delete this.targetFlags["grants.critical.range"];
+      if (distance > grantsCriticalRange) delete this.targetFlags["grants.critical.range"];
     }
   }
 

--- a/src/util.js
+++ b/src/util.js
@@ -37,3 +37,44 @@ export function getTarget() {
 export function isEmpty(obj) {
   return !Object.keys(obj).length;
 }
+
+export function getDistanceToTargetFn(speaker) {
+  return () => {
+    const controlledTokenDoc = game.scenes.get(speaker.scene).tokens.get(speaker.token);
+    const targetTokenDoc = game.user.targets.first()?.document;
+    if (!controlledTokenDoc || !targetTokenDoc) return Infinity;
+
+    // make rays from each controlled grid space to targeted grid space
+    const controlledSpaces = _getAllTokenGridSpaces(controlledTokenDoc);
+    const targetSpaces = _getAllTokenGridSpaces(targetTokenDoc);
+    const rays = controlledSpaces.flatMap((c) => targetSpaces.map((t) => ({ ray: new Ray(c, t) })));
+
+    // measure the horizontal distance: shortest distance between the two tokens' squares
+    const dist = canvas.scene.grid.distance;
+    const distances = canvas.grid
+      .measureDistances(rays, { gridSpaces: true })
+      .map((d) => Math.round(d / dist) * dist);
+    const horizDistance = Math.min(distances);
+
+    // compute vertical distance: diff in elevation
+    const verticalDistance = Math.abs(controlledTokenDoc.elevation - targetTokenDoc.elevation);
+    return Math.max(horizDistance, verticalDistance);
+  };
+}
+
+function _getAllTokenGridSpaces({ width, height, x, y }) {
+  // if the token is in a single space, just return that
+  if (width <= 1 && height <= 1) return [{ x, y }];
+  // create a position for each grid square it takes up
+  const grid = canvas.grid.size;
+  const centers = [];
+  for (let w = 0; w < width; w++) {
+    for (let h = 0; h < height; h++) {
+      centers.push({
+        x: x + w * grid,
+        y: y + h * grid,
+      });
+    }
+  }
+  return centers;
+}


### PR DESCRIPTION
Conditions like Paralyzed turn hits into crits if the attacker is adjacent. Helpful since a previous feature added this flag to the system-defined status effects.

There's an issue with Ready Set Roll though. It doesn't really do well with setting the critical flag in general, really just relying on whether the attack roll was a crit. So for now, it's effectively disabled by setting the distance to `Infinity` so the flag will be ignored.