### PR TITLE
fix #70

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# upcoming
+
+- bug fix: [#70](https://github.com/kaelad02/adv-reminder/issues/70) Fix error when using a damage or healing enricher
+
 # 4.0.0
 
 - feature: Support the system's new concentration rolls with sources and messages with `flags.adv-reminder.message.ability.concentration` (system already handles advantage/disadvantage)

--- a/src/rollers/core.js
+++ b/src/rollers/core.js
@@ -145,6 +145,9 @@ export default class CoreRollerHooks {
   preRollDamage(item, config) {
     debug("preRollDamage hook called");
 
+    // damage/healing enricher doesn't have an item, skip
+    if (!item) return;
+
     if (this.isFastForwarding(config)) return;
     const target = getTarget();
     const distanceFn = getDistanceToTargetFn(config.messageData.speaker);

--- a/src/rollers/midi.js
+++ b/src/rollers/midi.js
@@ -104,6 +104,9 @@ export default class MidiRollerHooks extends CoreRollerHooks {
   preRollDamage(item, config) {
     debug("preRollDamage hook called");
 
+    // damage/healing enricher doesn't have an item, skip
+    if (!item) return;
+
     if (this.isFastForwarding(config)) return;
     const target = getTarget();
     // use distance from Midi's Workflow

--- a/src/rollers/rsr.js
+++ b/src/rollers/rsr.js
@@ -138,6 +138,9 @@ export default class ReadySetRollHooks extends CoreRollerHooks {
   preRollDamage(item, config) {
     debug("preRollDamage hook called");
 
+    // damage/healing enricher doesn't have an item, skip
+    if (!item) return;
+
     const target = getTarget();
 
     if (this._doMessages(config)) {


### PR DESCRIPTION
The damage and healing enrichers don't have an item, so just skip it.