### PR TITLE
Reorganize wiki flag pages

### DIFF
--- a/docs/message-flags.md
+++ b/docs/message-flags.md
@@ -168,41 +168,130 @@ flags.adv-reminder.grants.message.damage.all
 | ---------------------------------------------- | ----------- | ------------------------------------ |
 | `flags.adv-reminder.grants.message.damage.all` | Custom      | `Critical roll if doing fire damage` |
 
-## Ability Checks 
+# Ability Checks
+
+```
+flags.adv-reminder.message.ability.check.all
+                                         [ability]
+```
+
+> <details>
+> <summary>Ability Abbreviations</summary>
+>
+> | Ability      | Abbreviation |
+> | ------------ | ------------ |
+> | Strength     | `str`        |
+> | Dexterity    | `dex`        |
+> | Constitution | `con`        |
+> | Wisdom       | `wis`        |
+> | Intelligence | `int`        |
+> | Charisma     | `cha`        |
+>
+> Source: `CONFIG.DND5E.abilities`
+> </details>
+
+### Message on All Ability Checks
+
+| Attribute Key                                  | Change Mode | Effect Value                      |
+| ---------------------------------------------- | ----------- | --------------------------------- |
+| `flags.adv-reminder.message.ability.check.all` | Custom      | `Advantage in certain situations` |
+
+### Message on Charisma Ability Checks
+
+| Attribute Key                                  | Change Mode | Effect Value                              |
+| ---------------------------------------------- | ----------- | ----------------------------------------- |
+| `flags.adv-reminder.message.ability.check.cha` | Custom      | `Advantage when interacting with Dwarves` |
 
 | Attribute Key | Description |
 |----|----|
-| flags.adv-reminder.message.all | Message on all rolls, including ability checks |
-| flags.adv-reminder.message.ability.all | Message on all ability checks, saves, and skills |
 | flags.adv-reminder.message.ability.check.all | Message on all ability checks |
 | flags.adv-reminder.message.ability.check.str/dex/con/int/wis/cha | Message on ability checks with a specific Ability Modifier |
 
-## Skill Checks
+# Skill Checks
 
-Since all skill checks are also ability checks, this list is in addition to the keys for Ability Checks.
+> [!NOTE]
+> Since all skill checks are also ability checks, messages on Ability Checks can also apply to Skill Checks.
 
-| Attribute Key | Description |
-|----|----|
-| flags.adv-reminder.message.skill.all | Message on all skill checks |
-| flags.adv-reminder.message.skill.acr/ani/arc/ath/dec/his/ins/itm/inv/med/nat/prc/prf/per/rel/slt/ste/sur | Message on specific Skills |
+```
+flags.adv-reminder.message.skill.all
+                                 [skill]
+```
 
-## Saving Throws 
+> <details>
+> <summary>Skill Abbreviations</summary>
+>
+> | Skill           | Abbreviation |
+> | --------------- | ------------ |
+> | Acrobatics      | `acr`        |
+> | Animal Handling | `ani`        |
+> | Arcana          | `arc`        |
+> | Athletics       | `ath`        |
+> | Deception       | `dec`        |
+> | History         | `his`        |
+> | Insight         | `ins`        |
+> | Investigation   | `inv`        |
+> | Intimidation    | `itm`        |
+> | Medicine        | `med`        |
+> | Nature          | `nat`        |
+> | Persuasion      | `per`        |
+> | Perception      | `prc`        |
+> | Performance     | `prf`        |
+> | Religion        | `rel`        |
+> | Sleight of Hand | `slt`        |
+> | Stealth         | `ste`        |
+> | Survival        | `sur`        |
+>
+> Source: `CONFIG.DND5E.skills`
+> </details>
 
-| Attribute Key | Description |
-|----|----|
-| flags.adv-reminder.message.all | Message on all rolls, including saving throws |
-| flags.adv-reminder.message.ability.all | Message on all ability checks, saves, and skills |
-| flags.adv-reminder.message.ability.save.all | Message on all saving throws |
-| flags.adv-reminder.message.ability.save.str/dex/con/int/wis/cha | Message on saving throws with a specific Ability Modifier |
+### Message on Deception Skill Checks
 
-## Death Saving Throw
+| Attribute Key                          | Change Mode | Effect Value                             |
+| -------------------------------------- | ----------- | ---------------------------------------- |
+| `flags.adv-reminder.message.skill.dec` | Custom      | `Imposter: Advantage to avoid detection` |
 
-| Attribute Key | Description |
-|----|----|
-| flags.adv-reminder.message.all | Message on all rolls, including death saves |
-| flags.adv-reminder.message.ability.all | Message on all ability checks, saves, and skills |
-| flags.adv-reminder.message.ability.save.all | Message on all saving throws |
-| flags.adv-reminder.message.deathSave | Message on death saving throws |
+# Saving Throws
+
+```
+flags.adv-reminder.message.ability.save.all
+                                        [ability]
+```
+
+> <details>
+> <summary>Ability Abbreviations</summary>
+>
+> | Ability      | Abbreviation |
+> | ------------ | ------------ |
+> | Strength     | `str`        |
+> | Dexterity    | `dex`        |
+> | Constitution | `con`        |
+> | Wisdom       | `wis`        |
+> | Intelligence | `int`        |
+> | Charisma     | `cha`        |
+>
+> Source: `CONFIG.DND5E.abilities`
+> </details>
+
+### Message on Constitution Saving Throws
+
+| Attribute Key                                 | Change Mode | Effect Value               |
+| --------------------------------------------- | ----------- | -------------------------- |
+| `flags.adv-reminder.message.ability.save.con` | Custom      | `Advantage against poison` |
+
+# Death Saving Throw
+
+> [!NOTE]
+> Since a death saving throw is a saving throw, messages on All Saving Throws will also apply to Death Saving Throws.
+
+```
+flags.adv-reminder.message.deathSave
+```
+
+### Message on Death Saving Throws
+
+| Attribute Key                          | Change Mode | Effect Value                            |
+| -------------------------------------- | ----------- | --------------------------------------- |
+| `flags.adv-reminder.message.deathSave` | Custom      | `[[/r 1d4]] bonus when in bright light` |
 
 # Shared Flags
 
@@ -210,6 +299,7 @@ While not commonly used, these apply to multiple types of rolls with just one fl
 
 ```
 flags.adv-reminder.message.all
+flags.adv-reminder.message.ability.all
 ```
 
 ### Message on All Rolls
@@ -217,3 +307,9 @@ flags.adv-reminder.message.all
 | Attribute Key                    | Change Mode | Effect Value                            |
 | -------------------------------- | ----------- | --------------------------------------- |
 | `flags.adv-reminder.message.all` | Custom      | `Advantage if within 10 feet of leader` |
+
+### Message on All Ability Checks, Saves, and Skill Rolls
+
+| Attribute Key                            | Change Mode | Effect Value                            |
+| ---------------------------------------- | ----------- | --------------------------------------- |
+| `flags.adv-reminder.message.ability.all` | Custom      | `Advantage if within 10 feet of leader` |

--- a/docs/message-flags.md
+++ b/docs/message-flags.md
@@ -1,30 +1,172 @@
 # Message Flags
 
-Here are the different type of Message flags that Advantage Reminder uses. All of these should be setup in the effects tab with the Change Mode of `Custom` and the Effect Value with the message you want.
+Here are the different type of Message flags that Advantage Reminder uses. All of these should be setup in the effects tab with the Change Mode of `Custom` and the Effect Value with the message you want. The message may include HTML formatting, deferred inline rolls, and document links.
 
-Some of the terms used in the keys are further explained in [Terms and Abbreviations](terms.md)
+# Attack Rolls
 
-## Attack Rolls
+Messages on attack rolls can either come from an effect on the attacker or target.
 
-| Attribute Key | Description |
-|----|----|
-| flags.adv-reminder.message.all | Message on all rolls, including attack rolls |
-| flags.adv-reminder.message.attack.all | Message on all attack rolls |
-| flags.adv-reminder.message.attack.mwak/rwak/msak/rsak | Message on attacks with a specific Action Type |
-| flags.adv-reminder.message.attack.str/dex/con/int/wis/cha | Message on attacks with a specific Ability Modifier |
-| flags.adv-reminder.grants.message.attack.all | Message when targeted by all attack rolls |
-| flags.adv-reminder.grants.message.attack.mwak/rwak/msak/rsak | Message when targeted by attacks with a specific Action Type |
-| flags.adv-reminder.grants.message.attack.str/dex/con/int/wis/cha | Message when targeted by attacks with a specific Ability Modifier |
+## Attacker
 
-## Damage Rolls
+These apply when they are the one making the attack roll.
 
-| Attribute Key | Description |
-|----|----|
-| flags.adv-reminder.message.all | Message on all rolls, including damage rolls |
-| flags.adv-reminder.message.damage.all | Message on all damage rolls |
-| flags.adv-reminder.message.damage.mwak/rwak/msak/rsak | Message on damage rolls with a specific Action Type |
-| flags.adv-reminder.grants.message.damage.all | Message when targeted by all damage rolls |
-| flags.adv-reminder.grants.message.damage.mwak/rwak/msak/rsak | Message when targeted by damage rolls with a specific Action Type |
+```
+flags.adv-reminder.message.attack.all
+                                  [type]
+                                  [ability]
+```
+
+> <details>
+> <summary>Action Types</summary>
+>
+> | Action Type          | Value  |
+> | -------------------- | -----  |
+> | Melee Spell Attack   | `msak` |
+> | Melee Weapon Attack  | `mwak` |
+> | Ranged Spell Attack  | `rsak` |
+> | Ranged Weapon Attack | `rwak` |
+>
+> Source: `CONFIG.DND5E.itemActionTypes`
+> </details>
+
+> <details>
+> <summary>Ability Abbreviations</summary>
+>
+> | Ability      | Abbreviation |
+> | ------------ | ------------ |
+> | Strength     | `str`        |
+> | Dexterity    | `dex`        |
+> | Constitution | `con`        |
+> | Wisdom       | `wis`        |
+> | Intelligence | `int`        |
+> | Charisma     | `cha`        |
+>
+> Source: `CONFIG.DND5E.abilities`
+> </details>
+
+### Message on All Attack Rolls
+
+| Attribute Key                           | Change Mode | Effect Value                  |
+| --------------------------------------- | ----------- | ----------------------------- |
+| `flags.adv-reminder.message.attack.all` | Custom      | `Advantage when in dim light` |
+
+### Message on Ranged Attack Rolls (both spell and weapon)
+
+| Attribute Key                            | Change Mode | Effect Value                          |
+| ---------------------------------------- | ----------- | ------------------------------------- |
+| `flags.adv-reminder.message.attack.rsak` | Custom      | `Disadvantage when adjacent to enemy` |
+| `flags.adv-reminder.message.attack.rwak` | Custom      | `Disadvantage when adjacent to enemy` |
+
+## Target of Attack
+
+These apply when they are the target of an attack. In other words, you are granting the attacker advantage or disadvantage.
+
+```
+flags.adv-reminder.grants.message.attack.all
+                                         [type]
+                                         [ability]
+```
+
+> <details>
+> <summary>Action Types</summary>
+>
+> | Action Type          | Value  |
+> | -------------------- | -----  |
+> | Melee Spell Attack   | `msak` |
+> | Melee Weapon Attack  | `mwak` |
+> | Ranged Spell Attack  | `rsak` |
+> | Ranged Weapon Attack | `rwak` |
+>
+> Source: `CONFIG.DND5E.itemActionTypes`
+> </details>
+
+> <details>
+> <summary>Ability Abbreviations</summary>
+>
+> | Ability      | Abbreviation |
+> | ------------ | ------------ |
+> | Strength     | `str`        |
+> | Dexterity    | `dex`        |
+> | Constitution | `con`        |
+> | Wisdom       | `wis`        |
+> | Intelligence | `int`        |
+> | Charisma     | `cha`        |
+>
+> Source: `CONFIG.DND5E.abilities`
+> </details>
+
+### Message When Targeted by Melee Attack Rolls (both spell and weapon)
+
+| Attribute Key                                   | Change Mode | Effect Value                                 |
+| ----------------------------------------------- | ----------- | -------------------------------------------- |
+| `flags.adv-reminder.grants.message.attack.msak` | Custom      | `Disadvantage if you can smell their stench` |
+| `flags.adv-reminder.grants.message.attack.mwak` | Custom      | `Disadvantage if you can smell their stench` |
+
+# Damage Rolls
+
+Messages on damage rolls can either come from an effect on the attacker or target.
+
+## Attacker
+
+These apply when they are the one making the damage roll.
+
+```
+flags.adv-reminder.message.damage.all
+                                  [type]
+```
+
+> <details>
+> <summary>Action Types</summary>
+>
+> | Action Type          | Value  |
+> | -------------------- | -----  |
+> | Melee Spell Attack   | `msak` |
+> | Melee Weapon Attack  | `mwak` |
+> | Ranged Spell Attack  | `rsak` |
+> | Ranged Weapon Attack | `rwak` |
+>
+> Source: `CONFIG.DND5E.itemActionTypes`
+> </details>
+
+### Message on All Damage Rolls
+
+| Attribute Key                           | Change Mode | Effect Value                                             |
+| --------------------------------------- | ----------- | -------------------------------------------------------- |
+| `flags.adv-reminder.message.damage.all` | Custom      | `[[/r 1d4]] bonus damage if you attacked with Advantage` |
+
+### Message on Weapon Damage Rolls (both melee and ranged)
+
+| Attribute Key                            | Change Mode | Effect Value                                            |
+| ---------------------------------------- | ----------- | ------------------------------------------------------- |
+| `flags.adv-reminder.message.damage.mwak` | Custom      | `[[/r @scale.rogue.sneak-attack]]{Sneak Attack} damage` |
+
+## Target of Attack
+
+These apply when they are the target of an attack. In other words, you are showing a message when someone rolls damage against you.
+
+```
+flags.adv-reminder.grants.message.damage.all
+                                         [type]
+```
+
+> <details>
+> <summary>Action Types</summary>
+>
+> | Action Type          | Value  |
+> | -------------------- | -----  |
+> | Melee Spell Attack   | `msak` |
+> | Melee Weapon Attack  | `mwak` |
+> | Ranged Spell Attack  | `rsak` |
+> | Ranged Weapon Attack | `rwak` |
+>
+> Source: `CONFIG.DND5E.itemActionTypes`
+> </details>
+
+### Message When Rolling All Damage Against
+
+| Attribute Key                                  | Change Mode | Effect Value                         |
+| ---------------------------------------------- | ----------- | ------------------------------------ |
+| `flags.adv-reminder.grants.message.damage.all` | Custom      | `Critical roll if doing fire damage` |
 
 ## Ability Checks 
 
@@ -61,3 +203,17 @@ Since all skill checks are also ability checks, this list is in addition to the 
 | flags.adv-reminder.message.ability.all | Message on all ability checks, saves, and skills |
 | flags.adv-reminder.message.ability.save.all | Message on all saving throws |
 | flags.adv-reminder.message.deathSave | Message on death saving throws |
+
+# Shared Flags
+
+While not commonly used, these apply to multiple types of rolls with just one flag.
+
+```
+flags.adv-reminder.message.all
+```
+
+### Message on All Rolls
+
+| Attribute Key                    | Change Mode | Effect Value                            |
+| -------------------------------- | ----------- | --------------------------------------- |
+| `flags.adv-reminder.message.all` | Custom      | `Advantage if within 10 feet of leader` |

--- a/docs/midi-flags.md
+++ b/docs/midi-flags.md
@@ -221,42 +221,112 @@ flags.midi-qol.disadvantage.ability.check.all
 | ----------------------------------------------- | ----------- | ------------ |
 | `flags.midi-qol.disadvantage.ability.check.all` | Custom      | `1`          |
 
-## Skill Checks
+# Skill Checks
 
-Since all skill checks are also ability checks, this list is in addition to the keys for Ability Checks.
+Note: Since all skill checks are also ability checks, advantage/disadvantage on an Ability Check can also apply to Skill Checks.
 
-| Attribute Key | Description |
-|----|----|
-| flags.midi-qol.advantage.skill.all | Advantage on all skill checks |
-| flags.midi-qol.advantage.skill.acr/ani/arc/ath/dec/his/ins/itm/inv/med/nat/prc/prf/per/rel/slt/ste/sur | Advantage on specific Skills |
-| flags.midi-qol.disadvantage.skill.all | Disadvantage on all skill checks |
-| flags.midi-qol.disadvantage.skill.acr/ani/arc/ath/dec/his/ins/itm/inv/med/nat/prc/prf/per/rel/slt/ste/sur | Disadvantage on specific Skills |
+```
+flags.midi-qol.advantage.skill.all
+                               [skill]
+flags.midi-qol.disadvantage.skill.all
+                                  [skill]
+```
 
-## Saving Throws
+> <details>
+> <summary>Skill Abbreviations</summary>
+>
+> | Skill           | Abbreviation |
+> | --------------- | ------------ |
+> | Acrobatics      | `acr`        |
+> | Animal Handling | `ani`        |
+> | Arcana          | `arc`        |
+> | Athletics       | `ath`        |
+> | Deception       | `dec`        |
+> | History         | `his`        |
+> | Insight         | `ins`        |
+> | Investigation   | `inv`        |
+> | Intimidation    | `itm`        |
+> | Medicine        | `med`        |
+> | Nature          | `nat`        |
+> | Persuasion      | `per`        |
+> | Perception      | `prc`        |
+> | Performance     | `prf`        |
+> | Religion        | `rel`        |
+> | Sleight of Hand | `slt`        |
+> | Stealth         | `ste`        |
+> | Survival        | `sur`        |
+>
+> Source: `CONFIG.DND5E.skills`
+> </details>
 
-| Attribute Key | Description |
-|----|----|
-| flags.midi-qol.advantage.all | Advantage on all rolls, including saving throws |
-| flags.midi-qol.advantage.ability.all | Advantage on all ability checks, saves, and skills |
-| flags.midi-qol.advantage.ability.save.all | Advantage on all saving throws |
-| flags.midi-qol.advantage.ability.save.str/dex/con/int/wis/cha | Advantage on saving throws with a specific Ability Modifier |
-| flags.midi-qol.disadvantage.all | Disadvantage on all rolls, including saving throws |
-| flags.midi-qol.disadvantage.ability.all | Disadvantage on all ability checks, saves, and skills |
-| flags.midi-qol.disadvantage.ability.save.all | Disadvantage on all saving throws |
-| flags.midi-qol.disadvantage.ability.save.str/dex/con/int/wis/cha | Disadvantage on saving throws with a specific Ability Modifier |
+### Advantage on Animal Handling Checks
 
-## Death Saving Throw
+| Attribute Key                        | Change Mode | Effect Value |
+| ------------------------------------ | ----------- | ------------ |
+| `flags.midi-qol.advantage.skill.ani` | Custom      | `1`          |
 
-| Attribute Key | Description |
-|----|----|
-| flags.midi-qol.advantage.all | Advantage on all rolls, including death saves |
-| flags.midi-qol.advantage.ability.all | Advantage on all ability checks, saves, and skills |
-| flags.midi-qol.advantage.ability.save.all | Advantage on all saving throws |
-| flags.midi-qol.advantage.deathSave | Advantage on death saving throws |
-| flags.midi-qol.disadvantage.all | Disadvantage on all rolls, including death saves |
-| flags.midi-qol.disadvantage.ability.all | Disadvantage on all ability checks, saves, and skills |
-| flags.midi-qol.disadvantage.ability.save.all | Disadvantage on all saving throws |
-| flags.midi-qol.disadvantage.deathSave | Disadvantage on death saving throws |
+### Disadvantage on Stealth Checks
+
+| Attribute Key                           | Change Mode | Effect Value |
+| --------------------------------------- | ----------- | ------------ |
+| `flags.midi-qol.disadvantage.skill.ste` | Custom      | `1`          |
+
+# Saving Throws
+
+```
+flags.midi-qol.advantage.ability.save.all
+                                      [ability]
+flags.midi-qol.disadvantage.ability.save.all
+                                         [ability]
+```
+
+> <details>
+> <summary>Ability Abbreviations</summary>
+>
+> | Ability      | Abbreviation |
+> | ------------ | ------------ |
+> | Strength     | `str`        |
+> | Dexterity    | `dex`        |
+> | Constitution | `con`        |
+> | Wisdom       | `wis`        |
+> | Intelligence | `int`        |
+> | Charisma     | `cha`        |
+>
+> Source: `CONFIG.DND5E.abilities`
+> </details>
+
+### Advantage on All Saving Throws
+
+| Attribute Key                               | Change Mode | Effect Value |
+| ------------------------------------------- | ----------- | ------------ |
+| `flags.midi-qol.advantage.ability.save.all` | Custom      | `1`          |
+
+### Disadvantage on Dexterity Saving Throws
+
+| Attribute Key                                  | Change Mode | Effect Value |
+| ---------------------------------------------- | ----------- | ------------ |
+| `flags.midi-qol.disadvantage.ability.save.dex` | Custom      | `1`          |
+
+# Death Saving Throw
+
+Note: Since a death saving throw is a saving throw, advantage/disadvantage on All Saving Throws will also apply to Death Saving Throws.
+
+```
+flags.midi-qol.advantage.deathSave
+flags.midi-qol.disadvantage.deathSave
+```
+
+### Advantage on Death Saving Throws
+
+| Attribute Key                        | Change Mode | Effect Value |
+| ------------------------------------ | ----------- | ------------ |
+| `flags.midi-qol.advantage.deathSave` | Custom      | `1`          |
+
+### Disadvantage on Death Saving Throws
+
+| Attribute Key                           | Change Mode | Effect Value |
+| --------------------------------------- | ----------- | ------------ |
+| `flags.midi-qol.disadvantage.deathSave` | Custom      | `1`          |
 
 # Shared Flags
 

--- a/docs/midi-flags.md
+++ b/docs/midi-flags.md
@@ -139,13 +139,13 @@ flags.midi-qol.noCritical.all
 ### Critical Hit on All Damage Rolls
 
 | Attribute Key                 | Change Mode | Effect Value |
-| ------------------------------| ----------- | ------------ |
+| ----------------------------- | ----------- | ------------ |
 | `flags.midi-qol.critical.all` | Custom      | `1`          |
 
 ### Critical Hit on All Weapon Damage Rolls (both melee and ranged)
 
 | Attribute Key                  | Change Mode | Effect Value |
-| -------------------------------| ----------- | ------------ |
+| ------------------------------ | ----------- | ------------ |
 | `flags.midi-qol.critical.mwak` | Custom      | `1`          |
 | `flags.midi-qol.critical.rwak` | Custom      | `1`          |
 
@@ -176,13 +176,13 @@ flags.midi-qol.fail.critical.all
 ### Grant Critical Hit on All Damage Rolls
 
 | Attribute Key                        | Change Mode | Effect Value |
-| -------------------------------------| ----------- | ------------ |
+| ------------------------------------ | ----------- | ------------ |
 | `flags.midi-qol.grants.critical.all` | Custom      | `1`          |
 
 ### Cancel Critical Hit Against All Damage Rolls
 
 | Attribute Key                      | Change Mode | Effect Value |
-| -----------------------------------| ----------- | ------------ |
+| ---------------------------------- | ----------- | ------------ |
 | `flags.midi-qol.fail.critical.all` | Custom      | `1`          |
 
 # Ability Checks

--- a/docs/midi-flags.md
+++ b/docs/midi-flags.md
@@ -1,6 +1,6 @@
 # Midi Flags
 
-This document covers the different types of Midi flags that Advantage Reminder supports for things like advantage, disadvantage, and critical roles.
+This document covers the different types of Midi flags that Advantage Reminder supports for things like advantage, disadvantage, and critical rolls.
 
 # Basic Usage
 

--- a/docs/midi-flags.md
+++ b/docs/midi-flags.md
@@ -8,15 +8,6 @@ When creating an active effect with these Midi flags, it is recommended to use t
 
 In general, flags that start with `flags.midi-qol.advantage` will give advantage on a roll and `flags.midi-qol.disadvantage` will give disadvantage. Flags will use these to start with and then further specify what kind or rolls they apply to.
 
-# Common Flags
-
-```
-flags.midi-qol.advantage.all
-flags.midi-qol.disadvantage.all
-```
-
-Not often used, but useful if you need an effect that applies to all d20 rolls.
-
 # Attack Rolls
 
 Advantage and disadvantage on attack rolls can either come from an effect on the attacker or target.
@@ -243,3 +234,26 @@ Since all skill checks are also ability checks, this list is in addition to the 
 | flags.midi-qol.disadvantage.ability.all | Disadvantage on all ability checks, saves, and skills |
 | flags.midi-qol.disadvantage.ability.save.all | Disadvantage on all saving throws |
 | flags.midi-qol.disadvantage.deathSave | Disadvantage on death saving throws |
+
+# Shared Flags
+
+While not commonly used, these apply to multiple types of rolls with just one flag.
+
+```
+flags.midi-qol.advantage.all
+flags.midi-qol.advantage.ability.all
+flags.midi-qol.disadvantage.all
+flags.midi-qol.disadvantage.ability.all
+```
+
+### Advantage on All d20 Rolls
+
+| Attribute Key                  | Change Mode | Effect Value |
+| ------------------------------ | ----------- | ------------ |
+| `flags.midi-qol.advantage.all` | Custom      | `1`          |
+
+### Advantage on All Ability Checks, Saves, and Skill Rolls
+
+| Attribute Key                          | Change Mode | Effect Value |
+| -------------------------------------- | ----------- | ------------ |
+| `flags.midi-qol.advantage.ability.all` | Custom      | `1`          |

--- a/docs/midi-flags.md
+++ b/docs/midi-flags.md
@@ -117,18 +117,82 @@ flags.midi-qol.grants.disadvantage.attack.all
 | ----------------------------------------------- | ----------- | ------------ |
 | `flags.midi-qol.grants.disadvantage.attack.all` | Custom      | `1`          |
 
-## Critical Hits
+# Critical Hits
 
-| Attribute Key | Description |
-|----|----|
-| flags.midi-qol.critical.all | Critical hit on all attacks |
-| flags.midi-qol.critical.mwak/rwak/msak/rsak | Critical hit on attacks with a specific Action Type |
-| flags.midi-qol.noCritical.all | Normal hit on all attacks |
-| flags.midi-qol.noCritical.mwak/rwak/msak/rsak | Normal hit on attacks with a specific Action Type |
-| flags.midi-qol.grants.critical.all | Critical hit when targeted by any attack |
-| flags.midi-qol.grants.critical.mwak/rwak/msak/rsak | Critical hit when targeted by attacks with a specific Action Type |
-| flags.midi-qol.fail.critical.all | Normal hit when targeted by any attack |
-| flags.midi-qol.fail.critical.mwak/rwak/msak/rsak | Normal hit when targeted by attacks with a specific Action Type |
+Critical hits can either come from an effect on the attacker or target.
+
+## Attacker
+
+These apply when they are the one making the attack roll.
+
+```
+flags.midi-qol.critical.all
+                        [type]
+flags.midi-qol.noCritical.all
+                          [type]
+```
+
+> <details>
+> <summary>Action Types</summary>
+>
+> | Action Type          | Value  |
+> | -------------------- | -----  |
+> | Melee Spell Attack   | `msak` |
+> | Melee Weapon Attack  | `mwak` |
+> | Ranged Spell Attack  | `rsak` |
+> | Ranged Weapon Attack | `rwak` |
+>
+> Source: `CONFIG.DND5E.itemActionTypes`
+> </details>
+
+### Critical Hit on All Damage Rolls
+
+| Attribute Key                 | Change Mode | Effect Value |
+| ------------------------------| ----------- | ------------ |
+| `flags.midi-qol.critical.all` | Custom      | `1`          |
+
+### Critical Hit on All Weapon Damage Rolls (both melee and ranged)
+
+| Attribute Key                  | Change Mode | Effect Value |
+| -------------------------------| ----------- | ------------ |
+| `flags.midi-qol.critical.mwak` | Custom      | `1`          |
+| `flags.midi-qol.critical.rwak` | Custom      | `1`          |
+
+## Target of Attack
+
+These apply when they are the target of an attack. In other words, you are granting the attacker a critical hit or canceling it.
+
+```
+flags.midi-qol.grants.critical.all
+                               [type]
+flags.midi-qol.fail.critical.all
+                             [type]
+```
+
+> <details>
+> <summary>Action Types</summary>
+>
+> | Action Type          | Value  |
+> | -------------------- | -----  |
+> | Melee Spell Attack   | `msak` |
+> | Melee Weapon Attack  | `mwak` |
+> | Ranged Spell Attack  | `rsak` |
+> | Ranged Weapon Attack | `rwak` |
+>
+> Source: `CONFIG.DND5E.itemActionTypes`
+> </details>
+
+### Grant Critical Hit on All Damage Rolls
+
+| Attribute Key                        | Change Mode | Effect Value |
+| -------------------------------------| ----------- | ------------ |
+| `flags.midi-qol.grants.critical.all` | Custom      | `1`          |
+
+### Cancel Critical Hit Against All Damage Rolls
+
+| Attribute Key                      | Change Mode | Effect Value |
+| -----------------------------------| ----------- | ------------ |
+| `flags.midi-qol.fail.critical.all` | Custom      | `1`          |
 
 ## Ability Checks
 

--- a/docs/midi-flags.md
+++ b/docs/midi-flags.md
@@ -1,25 +1,121 @@
 # Midi Flags
 
-Here are the different types of Midi flags that Advantage Reminder supports. All of these should be setup in the effects tab with the Change Mode of `Custom` and the Effect Value of `1`. They're treated like boolean settings with a `1` enabling it and a `0` disabling it.
+This document covers the different types of Midi flags that Advantage Reminder supports for things like advantage, disadvantage, and critical roles.
 
-Some of the terms used in the keys are further explained in [Terms and Abbreviations](terms.md)
+# Basic Usage
 
-## Attack Rolls
+When creating an active effect with these Midi flags, it is recommended to use the `Custom` Change Mode and a `1` for the Effect Value. These flags are treated like boolean settings with a `1` enabling it and a `0` disabling it.
 
-| Attribute Key | Description |
-|----|----|
-| flags.midi-qol.advantage.all | Advantage on all rolls, including attacks |
-| flags.midi-qol.advantage.attack.all | Advantage on all attack rolls |
-| flags.midi-qol.advantage.attack.mwak/rwak/msak/rsak | Advantage on attacks with a specific Action Type |
-| flags.midi-qol.advantage.attack.str/dex/con/int/wis/cha | Advantage on attacks with a specific Ability Modifier |
-| flags.midi-qol.disadvantage.all | Disadvantage on all rolls, including attacks |
-| flags.midi-qol.disadvantage.attack.all | Disadvantage on all attack rolls |
-| flags.midi-qol.disadvantage.attack.mwak/rwak/msak/rsak | Disadvantage on attacks with a specific Action Type |
-| flags.midi-qol.disadvantage.attack.str/dex/con/int/wis/cha | Disadvantage on attacks with a specific Ability Modifier |
-| flags.midi-qol.grants.advantage.attack.all | Advantage when targeted by any attack roll |
-| flags.midi-qol.grants.advantage.attack.mwak/rwak/msak/rsak | Advantage when targeted by attacks with a specific Action Type |
-| flags.midi-qol.grants.disadvantage.attack.all | Disadvantage when targeted by any attack roll |
-| flags.midi-qol.grants.disadvantage.attack.mwak/rwak/msak/rsak | Disadvantage when targeted by attacks with a specific Action Type |
+In general, flags that start with `flags.midi-qol.advantage` will give advantage on a roll and `flags.midi-qol.disadvantage` will give disadvantage. Flags will use these to start with and then further specify what kind or rolls they apply to.
+
+# Common Flags
+
+```
+flags.midi-qol.advantage.all
+flags.midi-qol.disadvantage.all
+```
+
+Not often used, but useful if you need an effect that applies to all d20 rolls.
+
+# Attack Rolls
+
+Advantage and disadvantage on attack rolls can either come from an effect on the attacker or target.
+
+## Attacker
+
+These apply when they are the one making the attack roll.
+
+```
+flags.midi-qol.advantage.attack.all
+                                [type]
+                                [ability]
+flags.midi-qol.disadvantage.attack.all
+                                   [type]
+                                   [ability]
+```
+
+> <details>
+> <summary>Action Types</summary>
+>
+> | Action Type          | Value  |
+> | -------------------- | -----  |
+> | Melee Spell Attack   | `msak` |
+> | Melee Weapon Attack  | `mwak` |
+> | Ranged Spell Attack  | `rsak` |
+> | Ranged Weapon Attack | `rwak` |
+>
+> Source: `CONFIG.DND5E.itemActionTypes`
+> </details>
+
+> <details>
+> <summary>Ability Abbreviations</summary>
+>
+> | Ability      | Abbreviation |
+> | ------------ | ------------ |
+> | Strength     | `str`        |
+> | Dexterity    | `dex`        |
+> | Constitution | `con`        |
+> | Wisdom       | `wis`        |
+> | Intelligence | `int`        |
+> | Charisma     | `cha`        |
+>
+> Source: `CONFIG.DND5E.abilities`
+> </details>
+
+### Advantage on All Attack Rolls
+
+| Attribute Key                         | Change Mode | Effect Value |
+| ------------------------------------- | ----------- | ------------ |
+| `flags.midi-qol.advantage.attack.all` | Custom      | `1`          |
+
+### Advantage on Melee Weapon Attack Rolls
+
+| Attribute Key                          | Change Mode | Effect Value |
+| -------------------------------------- | ----------- | ------------ |
+| `flags.midi-qol.advantage.attack.mwak` | Custom      | `1`          |
+
+### Advantage on Attack Rolls using Strength
+
+| Attribute Key                         | Change Mode | Effect Value |
+| ------------------------------------- | ----------- | ------------ |
+| `flags.midi-qol.advantage.attack.str` | Custom      | `1`          |
+
+## Target of Attack
+
+These apply when they are the target of an attack. In other words, you are granting the attacker advantage or disadvantage.
+
+```
+flags.midi-qol.grants.advantage.attack.all
+                                       [type]
+flags.midi-qol.grants.disadvantage.attack.all
+                                          [type]
+```
+
+> <details>
+> <summary>Action Types</summary>
+>
+> | Action Type          | Value  |
+> | -------------------- | -----  |
+> | Melee Spell Attack   | `msak` |
+> | Melee Weapon Attack  | `mwak` |
+> | Ranged Spell Attack  | `rsak` |
+> | Ranged Weapon Attack | `rwak` |
+>
+> Source: `CONFIG.DND5E.itemActionTypes`
+> </details>
+
+### Grant Advantage to All Melee Attack Rolls (both spell and weapon)
+
+| Attribute Key                                 | Change Mode | Effect Value |
+| --------------------------------------------  | ----------- | ------------ |
+| `flags.midi-qol.grants.advantage.attack.msak` | Custom      | `1`          |
+| `flags.midi-qol.grants.advantage.attack.mwak` | Custom      | `1`          |
+
+### Grant Disadvantage to All Attack Rolls
+
+| Attribute Key                                   | Change Mode | Effect Value |
+| ----------------------------------------------- | ----------- | ------------ |
+| `flags.midi-qol.grants.disadvantage.attack.all` | Custom      | `1`          |
 
 ## Critical Hits
 

--- a/docs/midi-flags.md
+++ b/docs/midi-flags.md
@@ -223,7 +223,8 @@ flags.midi-qol.disadvantage.ability.check.all
 
 # Skill Checks
 
-Note: Since all skill checks are also ability checks, advantage/disadvantage on an Ability Check can also apply to Skill Checks.
+> [!NOTE]
+> Since all skill checks are also ability checks, advantage/disadvantage on an Ability Check can also apply to Skill Checks.
 
 ```
 flags.midi-qol.advantage.skill.all
@@ -309,7 +310,8 @@ flags.midi-qol.disadvantage.ability.save.all
 
 # Death Saving Throw
 
-Note: Since a death saving throw is a saving throw, advantage/disadvantage on All Saving Throws will also apply to Death Saving Throws.
+> [!NOTE]
+> Since a death saving throw is a saving throw, advantage/disadvantage on All Saving Throws will also apply to Death Saving Throws.
 
 ```
 flags.midi-qol.advantage.deathSave

--- a/docs/midi-flags.md
+++ b/docs/midi-flags.md
@@ -185,18 +185,41 @@ flags.midi-qol.fail.critical.all
 | -----------------------------------| ----------- | ------------ |
 | `flags.midi-qol.fail.critical.all` | Custom      | `1`          |
 
-## Ability Checks
+# Ability Checks
 
-| Attribute Key | Description |
-|----|----|
-| flags.midi-qol.advantage.all | Advantage on all rolls, including ability checks |
-| flags.midi-qol.advantage.ability.all | Advantage on all ability checks, saves, and skills |
-| flags.midi-qol.advantage.ability.check.all | Advantage on all ability checks |
-| flags.midi-qol.advantage.ability.check.str/dex/con/int/wis/cha | Advantage on ability checks with a specific Ability Modifier |
-| flags.midi-qol.disadvantage.all | Disadvantage on all rolls, including ability checks |
-| flags.midi-qol.disadvantage.ability.all | Disadvantage on all ability checks, saves, and skills |
-| flags.midi-qol.disadvantage.ability.check.all | Disadvantage on all ability checks |
-| flags.midi-qol.disadvantage.ability.check.str/dex/con/int/wis/cha | Disadvantage on ability checks with a specific Ability Modifier |
+```
+flags.midi-qol.advantage.ability.check.all
+                                       [ability]
+flags.midi-qol.disadvantage.ability.check.all
+                                          [ability]
+```
+
+> <details>
+> <summary>Ability Abbreviations</summary>
+>
+> | Ability      | Abbreviation |
+> | ------------ | ------------ |
+> | Strength     | `str`        |
+> | Dexterity    | `dex`        |
+> | Constitution | `con`        |
+> | Wisdom       | `wis`        |
+> | Intelligence | `int`        |
+> | Charisma     | `cha`        |
+>
+> Source: `CONFIG.DND5E.abilities`
+> </details>
+
+### Advantage on Strength Ability Checks
+
+| Attribute Key                                | Change Mode | Effect Value |
+| -------------------------------------------- | ----------- | ------------ |
+| `flags.midi-qol.advantage.ability.check.str` | Custom      | `1`          |
+
+### Disadvantage on All Ability Checks
+
+| Attribute Key                                   | Change Mode | Effect Value |
+| ----------------------------------------------- | ----------- | ------------ |
+| `flags.midi-qol.disadvantage.ability.check.all` | Custom      | `1`          |
 
 ## Skill Checks
 


### PR DESCRIPTION
Follow the dnd5e wiki page format, e.g. https://github.com/foundryvtt/dnd5e/wiki/Active-Effect-Guide, to hopefully make it easier to use. I would like to improve the examples, but what's there will do for now.