### PR TITLE
Dnd 4.1.2 fix

### DIFF
--- a/src/messages.js
+++ b/src/messages.js
@@ -151,9 +151,10 @@ export class SkillMessage extends AbilityCheckMessage {
 
   /** @override */
   get messageKeys() {
-    return [
+    return super.messageKeys.concat(
       "flags.adv-reminder.message.skill.all",
-      `flags.adv-reminder.message.skill.${this.skillId}`]
+      `flags.adv-reminder.message.skill.${this.skillId}`
+    );
   }
 }
 
@@ -164,7 +165,10 @@ export class DeathSaveMessage extends AbilityBaseMessage {
 
   /** @override */
   get messageKeys() {
-    return ["flags.adv-reminder.message.deathSave"]
+    return super.messageKeys.concat(
+      "flags.adv-reminder.message.ability.save.all",
+      "flags.adv-reminder.message.deathSave"
+    );
   }
 }
 

--- a/src/messages.js
+++ b/src/messages.js
@@ -27,7 +27,7 @@ class BaseMessage {
   }
 
   get prefix() {
-    return "dialogOptions";
+    return "options";
   }
 
   addMessage(options) {
@@ -151,10 +151,9 @@ export class SkillMessage extends AbilityCheckMessage {
 
   /** @override */
   get messageKeys() {
-    return super.messageKeys.concat(
+    return [
       "flags.adv-reminder.message.skill.all",
-      `flags.adv-reminder.message.skill.${this.skillId}`
-    );
+      `flags.adv-reminder.message.skill.${this.skillId}`]
   }
 }
 
@@ -165,10 +164,7 @@ export class DeathSaveMessage extends AbilityBaseMessage {
 
   /** @override */
   get messageKeys() {
-    return super.messageKeys.concat(
-      "flags.adv-reminder.message.ability.save.all",
-      "flags.adv-reminder.message.deathSave"
-    );
+    return ["flags.adv-reminder.message.deathSave"]
   }
 }
 

--- a/src/reminders.js
+++ b/src/reminders.js
@@ -271,16 +271,15 @@ export class SkillReminder extends AbilityCheckReminder {
 
   /** @override */
   get advantageKeys() {
-    return [
-      "advantage.skill.all",
-      `advantage.skill.${this.skillId}`];
+    return super.advantageKeys.concat(["advantage.skill.all", `advantage.skill.${this.skillId}`]);
   }
 
   /** @override */
   get disadvantageKeys() {
-    return [
+    return super.disadvantageKeys.concat([
       "disadvantage.skill.all",
-      `disadvantage.skill.${this.skillId}`,];
+      `disadvantage.skill.${this.skillId}`,
+    ]);
   }
 
   /** @override */
@@ -323,14 +322,16 @@ export class DeathSaveReminder extends AbilityBaseReminder {
   }
 
   /** @override */
-  /** @override */
   get advantageKeys() {
-    return ["advantage.deathSave"];
+    return super.advantageKeys.concat(["advantage.ability.save.all", "advantage.deathSave"]);
   }
 
   /** @override */
   get disadvantageKeys() {
-    return ["disadvantage.deathSave"];
+    return super.disadvantageKeys.concat([
+      "disadvantage.ability.save.all",
+      "disadvantage.deathSave",
+    ]);
   }
 }
 

--- a/src/reminders.js
+++ b/src/reminders.js
@@ -271,15 +271,16 @@ export class SkillReminder extends AbilityCheckReminder {
 
   /** @override */
   get advantageKeys() {
-    return super.advantageKeys.concat(["advantage.skill.all", `advantage.skill.${this.skillId}`]);
+    return [
+      "advantage.skill.all",
+      `advantage.skill.${this.skillId}`];
   }
 
   /** @override */
   get disadvantageKeys() {
-    return super.disadvantageKeys.concat([
+    return [
       "disadvantage.skill.all",
-      `disadvantage.skill.${this.skillId}`,
-    ]);
+      `disadvantage.skill.${this.skillId}`,];
   }
 
   /** @override */
@@ -322,16 +323,14 @@ export class DeathSaveReminder extends AbilityBaseReminder {
   }
 
   /** @override */
+  /** @override */
   get advantageKeys() {
-    return super.advantageKeys.concat(["advantage.ability.save.all", "advantage.deathSave"]);
+    return ["advantage.deathSave"];
   }
 
   /** @override */
   get disadvantageKeys() {
-    return super.disadvantageKeys.concat([
-      "disadvantage.ability.save.all",
-      "disadvantage.deathSave",
-    ]);
+    return ["disadvantage.deathSave"];
   }
 }
 

--- a/src/rollers/core.js
+++ b/src/rollers/core.js
@@ -48,12 +48,12 @@ export default class CoreRollerHooks {
 
     // register all the dnd5e.pre hooks
     Hooks.on("dnd5e.preRollAttackV2", this.preRollAttackV2.bind(this));
-    Hooks.on("dnd5e.preRollAbilitySave", this.preRollAbilitySave.bind(this));
-    Hooks.on("dnd5e.preRollConcentration", this.preRollConcentration.bind(this));
-    Hooks.on("dnd5e.preRollAbilityTest", this.preRollAbilityTest.bind(this));
-    Hooks.on("dnd5e.preRollSkill", this.preRollSkill.bind(this));
-    Hooks.on("dnd5e.preRollToolCheck", this.preRollToolCheck.bind(this));
-    Hooks.on("dnd5e.preRollDeathSave", this.preRollDeathSave.bind(this));
+    Hooks.on("dnd5e.preRollSkillV2", this.preRollSkillV2.bind(this));
+    Hooks.on("dnd5e.preRollAbilityCheckV2", this.preRollAbilityCheckV2.bind(this));  
+    Hooks.on("dnd5e.preRollSavingThrowV2", this.preRollSavingThrowV2.bind(this));
+    //Hooks.on("dnd5e.preRollToolV2", this.preRollToolV2.bind(this));
+    Hooks.on("dnd5e.preRollDeathSaveV2", this.preRollDeathSaveV2.bind(this));
+    Hooks.on("dnd5e.preRollConcentrationV2", this.preRollConcentrationV2.bind(this));
     Hooks.on("dnd5e.preRollDamageV2", this.preRollDamageV2.bind(this));
   }
 
@@ -77,70 +77,68 @@ export default class CoreRollerHooks {
     if (showSources) new AttackSourceV2(activity.actor, target, activity, distanceFn).updateOptions(dialog);
     new AttackReminderV2(activity.actor, target, activity, distanceFn).updateOptions(config.rolls[0].options);
   }
-
-  preRollAbilitySave(actor, config, abilityId) {
+  
+  preRollSavingThrowV2(config, dialog, message) {
     debug("preRollAbilitySave hook called");
 
-    const failChecker = new AbilitySaveFail(actor, abilityId);
+    const failChecker = new AbilitySaveFail(config.subject, config.ability);
     if (failChecker.fails(config)) return false;
 
-    if (this.isFastForwarding(config)) return;
+    if (this.isFastForwarding(config, dialog)) return;
 
-    new AbilitySaveMessage(actor, abilityId).addMessage(config);
-    if (showSources) new AbilitySaveSource(actor, abilityId).updateOptions(config);
-    new AbilitySaveReminder(actor, abilityId).updateOptions(config);
+    new AbilitySaveMessage(config.subject, config.ability).addMessage(dialog);
+    if (showSources) new AbilitySaveSource(config.subject, config.ability).updateOptions(dialog);
+    new AbilitySaveReminder(config.subject, config.ability).updateOptions(dialog);
   }
-
-  preRollConcentration(actor, options) {
+  
+  preRollConcentrationV2(config, dialog, message) {
     debug("preRollConcentration hook called");
 
-    if (this.isFastForwarding(options)) return;
+    if (this.isFastForwarding(config, dialog)) return;
 
-    new ConcentrationMessage(actor, options.ability).addMessage(options);
-    if (showSources) new ConcentrationSource(actor, options.ability).updateOptions(options);
+    new ConcentrationMessage(config.subject, config.ability).addMessage(dialog);
+    if (showSources) new ConcentrationSource(config.subject, config.ability).updateOptions(dialog);
     // don't need a reminder, the system will set advantage/disadvantage
   }
 
-  preRollAbilityTest(actor, config, abilityId) {
+  preRollAbilityCheckV2(config, dialog, message) {
     debug("preRollAbilityTest hook called");
 
-    if (this.isFastForwarding(config)) return;
-
-    new AbilityCheckMessage(actor, abilityId).addMessage(config);
-    if (showSources) new AbilityCheckSource(actor, abilityId).updateOptions(config);
-    new AbilityCheckReminder(actor, abilityId).updateOptions(config);
+    if (this.isFastForwarding(config, dialog)) return;
+   
+    new AbilityCheckMessage(config.subject, config.ability).addMessage(dialog);
+    if (showSources) new AbilityCheckSource(config.subject, config.ability).updateOptions(dialog);
+    new AbilityCheckReminder(config.subject, config.ability).updateOptions(dialog); 
   }
 
-  preRollSkill(actor, config, skillId) {
-    debug("preRollSkill hook called");
+  preRollSkillV2(config, dialog, message) {
+    debug("preRollSkillV2 hook called");
+    
+    if (this.isFastForwarding(config, dialog)) return;
 
-    if (this.isFastForwarding(config)) return;
-
-    const ability = config.data.defaultAbility;
-    new SkillMessage(actor, ability, skillId).addMessage(config);
-    if (showSources) new SkillSource(actor, ability, skillId, true).updateOptions(config);
-    new SkillReminder(actor, ability, skillId, this.checkArmorStealth).updateOptions(config);
+    new SkillMessage(config.subject, config.ability, config.skill).addMessage(dialog);
+    if (showSources) new SkillSource(config.subject, config.ability, config.skill, true).updateOptions(dialog);
+    new SkillReminder(config.subject, config.ability, config.skill, this.checkArmorStealth).updateOptions(dialog);
   }
 
-  preRollToolCheck(actor, config, toolId) {
+  /**preRollToolV2(config, dialog, message)  {//toDo: Missing Message for tools
     debug("preRollToolCheck hook called");
 
-    if (this.isFastForwarding(config)) return;
+    if (this.isFastForwarding(config, dialog)) return;
 
-    const ability = config.data.defaultAbility;
-    new AbilityCheckMessage(actor, ability).addMessage(config);
-    if (showSources) new AbilityCheckSource(actor, ability).updateOptions(config);
-    new AbilityCheckReminder(actor, ability).updateOptions(config);
-  }
+    new AbilityCheckMessage(config.subject, config.ability).addMessage(dialog);
+    if (showSources) new AbilityCheckSource(config.subject, config.ability).updateOptions(dialog);
+    new AbilityCheckReminder(config.subject, config.ability).updateOptions(dialog);
+  }*/
 
-  preRollDeathSave(actor, config) {
+  preRollDeathSaveV2(config, dialog, message)  {
     debug("preRollDeathSave hook called");
 
-    if (this.isFastForwarding(config)) return;
+    if (this.isFastForwarding(config, dialog)) return;
 
-    new DeathSaveMessage(actor).addMessage(config);
-    if (showSources) new DeathSaveSource(actor).updateOptions(config);
-    new DeathSaveReminder(actor).updateOptions(config);
+    new DeathSaveMessage(config.subject).addMessage(dialog);
+    if (showSources) new DeathSaveSource(config.subject).updateOptions(dialog);
+    new DeathSaveReminder(config.subject).updateOptions(dialog);
   }
 
   preRollDamageV2(config, dialog, message) {

--- a/src/rollers/core.js
+++ b/src/rollers/core.js
@@ -79,7 +79,7 @@ export default class CoreRollerHooks {
   }
   
   preRollSavingThrowV2(config, dialog, message) {
-    debug("preRollAbilitySave hook called");
+    debug("preRollSavingThrowV2 hook called");
 
     const failChecker = new AbilitySaveFail(config.subject, config.ability);
     if (failChecker.fails(config)) return false;
@@ -92,7 +92,7 @@ export default class CoreRollerHooks {
   }
   
   preRollConcentrationV2(config, dialog, message) {
-    debug("preRollConcentration hook called");
+    debug("preRollConcentrationV2 hook called");
 
     if (this.isFastForwarding(config, dialog)) return;
 
@@ -102,7 +102,7 @@ export default class CoreRollerHooks {
   }
 
   preRollAbilityCheckV2(config, dialog, message) {
-    debug("preRollAbilityTest hook called");
+    debug("preRollAbilityCheckV2 hook called");
 
     if (this.isFastForwarding(config, dialog)) return;
    
@@ -132,7 +132,7 @@ export default class CoreRollerHooks {
   }*/
 
   preRollDeathSaveV2(config, dialog, message)  {
-    debug("preRollDeathSave hook called");
+    debug("preRollDeathSaveV2 hook called");
 
     if (this.isFastForwarding(config, dialog)) return;
 

--- a/src/rollers/core.js
+++ b/src/rollers/core.js
@@ -88,7 +88,7 @@ export default class CoreRollerHooks {
 
     new AbilitySaveMessage(config.subject, config.ability).addMessage(dialog);
     if (showSources) new AbilitySaveSource(config.subject, config.ability).updateOptions(dialog);
-    new AbilitySaveReminder(config.subject, config.ability).updateOptions(dialog);
+    new AbilitySaveReminder(config.subject, config.ability).updateOptions(config.rolls[0].options);
   }
   
   preRollConcentrationV2(config, dialog, message) {
@@ -108,7 +108,7 @@ export default class CoreRollerHooks {
    
     new AbilityCheckMessage(config.subject, config.ability).addMessage(dialog);
     if (showSources) new AbilityCheckSource(config.subject, config.ability).updateOptions(dialog);
-    new AbilityCheckReminder(config.subject, config.ability).updateOptions(dialog); 
+    new AbilityCheckReminder(config.subject, config.ability).updateOptions(config.rolls[0].options); 
   }
 
   preRollSkillV2(config, dialog, message) {
@@ -118,7 +118,7 @@ export default class CoreRollerHooks {
 
     new SkillMessage(config.subject, config.ability, config.skill).addMessage(dialog);
     if (showSources) new SkillSource(config.subject, config.ability, config.skill, true).updateOptions(dialog);
-    new SkillReminder(config.subject, config.ability, config.skill, this.checkArmorStealth).updateOptions(dialog);
+    new SkillReminder(config.subject, config.ability, config.skill, this.checkArmorStealth).updateOptions(config.rolls[0].options);
   }
 
   /**preRollToolV2(config, dialog, message)  {//toDo: Missing Message for tools
@@ -138,7 +138,7 @@ export default class CoreRollerHooks {
 
     new DeathSaveMessage(config.subject).addMessage(dialog);
     if (showSources) new DeathSaveSource(config.subject).updateOptions(dialog);
-    new DeathSaveReminder(config.subject).updateOptions(dialog);
+    new DeathSaveReminder(config.subject).updateOptions(config.rolls[0].options);
   }
 
   preRollDamageV2(config, dialog, message) {

--- a/src/rollers/rsr.js
+++ b/src/rollers/rsr.js
@@ -40,15 +40,12 @@ export default class ReadySetRollHooks extends CoreRollerHooks {
   init() {
     // delay registering these dnd5e hooks so they run after RSR's hooks
     Hooks.once("setup", () => {
-      super.init();
-
-      // register another hook for CriticalReminder
-      //Hooks.on("dnd5e.useItem", this.useItem.bind(this));  
+      super.init(); 
     });
   }
 
   preRollAttackV2(config, dialog, message) {
-    debug("preRollAttack hook called");
+    debug("preRollAttackV2 hook called");
 
     const target = getTarget();
     const distanceFn = getDistanceToTargetFn(message.data.speaker);
@@ -64,7 +61,7 @@ export default class ReadySetRollHooks extends CoreRollerHooks {
   }
 
   preRollSavingThrowV2(config, dialog, message){
-    debug("preRollAbilitySave hook called");
+    debug("preRollSavingThrowV2 hook called");
 
     const failChecker = new AbilitySaveFail(config.subject, config.ability);
     if (failChecker.fails(config)) return false;
@@ -78,7 +75,7 @@ export default class ReadySetRollHooks extends CoreRollerHooks {
   }
 
   preRollConcentrationV2(config, dialog, message) {
-    debug("preRollConcentration hook called");
+    debug("preRollConcentrationV2 hook called");
 
     if (this._doMessages(options)) {
       new ConcentrationMessage(config.subject, config.ability).addMessage(dialog);
@@ -88,7 +85,7 @@ export default class ReadySetRollHooks extends CoreRollerHooks {
   }
 
   preRollAbilityCheckV2(config, dialog, message)  {
-    debug("preRollAbilityTest hook called");
+    debug("preRollAbilityCheckV2 hook called");
 
     if (this._doMessages(config)) {
       new AbilityCheckMessage(config.subject, config.ability).addMessage(dialog);
@@ -99,7 +96,7 @@ export default class ReadySetRollHooks extends CoreRollerHooks {
   }
 
   preRollSkillV2(config, dialog, message) {
-    debug("preRollSkill hook called");
+    debug("preRollSkillV2 hook called");
     
     if (this._doMessages(config)) {
       new SkillMessage(config.subject, config.ability, config.skill).addMessage(dialog);
@@ -125,7 +122,7 @@ export default class ReadySetRollHooks extends CoreRollerHooks {
   // }
 
   preRollDeathSaveV2(config, dialog, message) {
-    debug("preRollDeathSave hook called");
+    debug("preRollDeathSaveV2 hook called");
 
     if (this._doMessages(config)) {
       new DeathSaveMessage(config.subject).addMessage(dialog);
@@ -136,7 +133,7 @@ export default class ReadySetRollHooks extends CoreRollerHooks {
   }
 
   preRollDamageV2(config, dialog, message) {
-    debug("preRollDamage hook called");
+    debug("preRollDamageV2 hook called");
 
     // damage/healing enricher doesn't have an item, skip
     if (!config.subject) return;
@@ -149,18 +146,9 @@ export default class ReadySetRollHooks extends CoreRollerHooks {
       new DamageMessageV2(activity.actor, target, activity).addMessage(dialog);
       if (showSources) new CriticalSourceV2(activity.actor, target, activity, distanceFn).updateOptions(dialog);
       const reminder = new CriticalReminderV2(activity.actor, target, activity, distanceFn);
-      config.rolls.forEach(roll => reminder.updateOptions(roll.options, "isCrit"));
+      config.rolls.forEach(roll => reminder.updateOptions(roll.options, "isCritical"));
     }
-    // don't use CriticalReminder here, it's done in another hook
   }
-
-  // useItem(item, config, options) {
-  //   debug("useItem hook called");
-
-  //   // check for critical hits but set the "isCrit" property instead of the default "critical"
-  //   const target = getTarget();
-  //   new CriticalReminder(item.actor, target, item, distanceFn).updateOptions(config, "isCrit");
-  // }
 
   _doMessages({ fastForward = false }) {
     if (fastForward) debug("fast-forwarding the roll, skip messages");

--- a/src/sources.js
+++ b/src/sources.js
@@ -55,7 +55,7 @@ const SourceMixin = (superclass) =>
     }
 
     get _prefix() {
-      return "dialogOptions";
+      return "options";
     }
 
     _accumulator() {

--- a/src/sources.js
+++ b/src/sources.js
@@ -184,6 +184,7 @@ export class CriticalSourceV2 extends SourceMixin(CriticalReminderV2) {
   get _prefix() {
     return "options";
   }
+
   _adjustRange(distanceFn, grantsCriticalRange) {
     // check if the range applies, remove flag if not
     if ("grants.critical.range" in this.targetFlags) {
@@ -195,7 +196,6 @@ export class CriticalSourceV2 extends SourceMixin(CriticalReminderV2) {
   _accumulator() {
     const criticalLabels = [];
     const normalLabels = [];
-    console.log("Here Accu Crit");
 
     return {
       add: (changes, critKeys, normalKeys) => {
@@ -206,9 +206,9 @@ export class CriticalSourceV2 extends SourceMixin(CriticalReminderV2) {
           if(changes[key]) normalLabels.push(...changes[key]);
         });
       },
-       critical: (label) => {
-         if (label) criticalLabels.push(label);
-       },
+      critical: (label) => {
+        if (label) criticalLabels.push(label);
+      },
       update: (options) => {
         debug("criticalLabels", criticalLabels, "normalLabels", normalLabels);
         const merge = (newLabels, key) => {
@@ -223,5 +223,4 @@ export class CriticalSourceV2 extends SourceMixin(CriticalReminderV2) {
       },
     };
   }
-  
 }

--- a/src/sources.js
+++ b/src/sources.js
@@ -184,4 +184,44 @@ export class CriticalSourceV2 extends SourceMixin(CriticalReminderV2) {
   get _prefix() {
     return "options";
   }
+  _adjustRange(distanceFn, grantsCriticalRange) {
+    // check if the range applies, remove flag if not
+    if ("grants.critical.range" in this.targetFlags) {
+      const distance = distanceFn();
+      if (distance > grantsCriticalRange) delete this.targetFlags["grants.critical.range"];
+    }
+  }
+
+  _accumulator() {
+    const criticalLabels = [];
+    const normalLabels = [];
+    console.log("Here Accu Crit");
+
+    return {
+      add: (changes, critKeys, normalKeys) => {
+        critKeys.forEach(key => {
+          if (changes[key]) criticalLabels.push(...changes[key]);
+        });
+        normalKeys.forEach(key => {
+          if(changes[key]) normalLabels.push(...changes[key]);
+        });
+      },
+       critical: (label) => {
+         if (label) criticalLabels.push(label);
+       },
+      update: (options) => {
+        debug("criticalLabels", criticalLabels, "normalLabels", normalLabels);
+        const merge = (newLabels, key) => {
+          if (newLabels.length) {
+            const labels = foundry.utils.getProperty(options, key);
+            if (labels) newLabels.push(...labels);
+            foundry.utils.setProperty(options, key, newLabels);
+          }
+        };
+        merge(criticalLabels, `${this._prefix}.adv-reminder.criticalLabels`);
+        merge(normalLabels, `${this._prefix}.adv-reminder.normalLabels`);
+      },
+    };
+  }
+  
 }

--- a/test/messages.test.js
+++ b/test/messages.test.js
@@ -51,7 +51,7 @@ describe("AttackMessage no legit active effects", () => {
 
     new AttackMessage(actor, undefined, item).addMessage(options);
 
-    expect(options.dialogOptions).toBeUndefined();
+    expect(options.options).toBeUndefined();
   });
 });
 
@@ -63,7 +63,7 @@ describe("AttackMessage message flags", () => {
 
     new AttackMessage(actor, undefined, item).addMessage(options);
 
-    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual(["message.all message"]);
+    expect(options.options["adv-reminder"].messages).toStrictEqual(["message.all message"]);
   });
 
   test("attack with message.attack.all flag should add the message", () => {
@@ -76,7 +76,7 @@ describe("AttackMessage message flags", () => {
 
     new AttackMessage(actor, undefined, item).addMessage(options);
 
-    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual([
+    expect(options.options["adv-reminder"].messages).toStrictEqual([
       "message.attack.all message",
     ]);
   });
@@ -91,7 +91,7 @@ describe("AttackMessage message flags", () => {
 
     new AttackMessage(actor, undefined, item).addMessage(options);
 
-    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual([
+    expect(options.options["adv-reminder"].messages).toStrictEqual([
       "message.attack.mwak message",
     ]);
   });
@@ -106,7 +106,7 @@ describe("AttackMessage message flags", () => {
 
     new AttackMessage(actor, undefined, item).addMessage(options);
 
-    expect(options.dialogOptions).toBeUndefined();
+    expect(options.options).toBeUndefined();
   });
 
   test("attack with message.attack.cha flag should add the message for Charisma Attack", () => {
@@ -119,7 +119,7 @@ describe("AttackMessage message flags", () => {
 
     new AttackMessage(actor, undefined, item).addMessage(options);
 
-    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual([
+    expect(options.options["adv-reminder"].messages).toStrictEqual([
       "message.attack.cha message",
     ]);
   });
@@ -134,7 +134,7 @@ describe("AttackMessage message flags", () => {
 
     new AttackMessage(actor, undefined, item).addMessage(options);
 
-    expect(options.dialogOptions).toBeUndefined();
+    expect(options.options).toBeUndefined();
   });
 
   test("attack with two messages should add both messages", () => {
@@ -147,7 +147,7 @@ describe("AttackMessage message flags", () => {
 
     new AttackMessage(actor, undefined, item).addMessage(options);
 
-    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual(["first", "second"]);
+    expect(options.options["adv-reminder"].messages).toStrictEqual(["first", "second"]);
   });
 });
 
@@ -163,7 +163,7 @@ describe("AttackMessage from target", () => {
 
     new AttackMessage(actor, target, item).addMessage(options);
 
-    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual([
+    expect(options.options["adv-reminder"].messages).toStrictEqual([
       "message.attack.all message",
     ]);
   });
@@ -179,7 +179,7 @@ describe("AttackMessage from target", () => {
 
     new AttackMessage(actor, target, item).addMessage(options);
 
-    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual([
+    expect(options.options["adv-reminder"].messages).toStrictEqual([
       "message.attack.mwak message",
     ]);
   });
@@ -195,7 +195,7 @@ describe("AttackMessage from target", () => {
 
     new AttackMessage(actor, target, item).addMessage(options);
 
-    expect(options.dialogOptions).toBeUndefined();
+    expect(options.options).toBeUndefined();
   });
 
   test("attack with message.attack.cha flag should add the message for Charisma Attack", () => {
@@ -209,7 +209,7 @@ describe("AttackMessage from target", () => {
 
     new AttackMessage(actor, target, item).addMessage(options);
 
-    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual([
+    expect(options.options["adv-reminder"].messages).toStrictEqual([
       "message.attack.cha message",
     ]);
   });
@@ -225,7 +225,7 @@ describe("AttackMessage from target", () => {
 
     new AttackMessage(actor, target, item).addMessage(options);
 
-    expect(options.dialogOptions).toBeUndefined();
+    expect(options.options).toBeUndefined();
   });
 
   test("attack with two messages should add both messages", () => {
@@ -239,7 +239,7 @@ describe("AttackMessage from target", () => {
 
     new AttackMessage(actor, target, item).addMessage(options);
 
-    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual(["first", "second"]);
+    expect(options.options["adv-reminder"].messages).toStrictEqual(["first", "second"]);
   });
 });
 
@@ -250,7 +250,7 @@ describe("AbilityCheckMessage no legit active effects", () => {
 
     new AbilityCheckMessage(actor, "int").addMessage(options);
 
-    expect(options.dialogOptions).toBeUndefined();
+    expect(options.options).toBeUndefined();
   });
 });
 
@@ -261,7 +261,7 @@ describe("AbilityCheckMessage message flags", () => {
 
     new AbilityCheckMessage(actor, "int").addMessage(options);
 
-    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual(["message.all message"]);
+    expect(options.options["adv-reminder"].messages).toStrictEqual(["message.all message"]);
   });
 
   test("ability check with message.ability.all flag should add the message", () => {
@@ -273,7 +273,7 @@ describe("AbilityCheckMessage message flags", () => {
 
     new AbilityCheckMessage(actor, "int").addMessage(options);
 
-    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual([
+    expect(options.options["adv-reminder"].messages).toStrictEqual([
       "message.ability.all message",
     ]);
   });
@@ -287,7 +287,7 @@ describe("AbilityCheckMessage message flags", () => {
 
     new AbilityCheckMessage(actor, "int").addMessage(options);
 
-    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual([
+    expect(options.options["adv-reminder"].messages).toStrictEqual([
       "message.ability.check.all message",
     ]);
   });
@@ -301,7 +301,7 @@ describe("AbilityCheckMessage message flags", () => {
 
     new AbilityCheckMessage(actor, "int").addMessage(options);
 
-    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual([
+    expect(options.options["adv-reminder"].messages).toStrictEqual([
       "message.ability.check.int message",
     ]);
   });
@@ -315,7 +315,7 @@ describe("AbilityCheckMessage message flags", () => {
 
     new AbilityCheckMessage(actor, "dex").addMessage(options);
 
-    expect(options.dialogOptions).toBeUndefined();
+    expect(options.options).toBeUndefined();
   });
 
   test("ability check with two messages should add both messages", () => {
@@ -327,7 +327,7 @@ describe("AbilityCheckMessage message flags", () => {
 
     new AbilityCheckMessage(actor, "dex").addMessage(options);
 
-    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual(["first", "second"]);
+    expect(options.options["adv-reminder"].messages).toStrictEqual(["first", "second"]);
   });
 });
 
@@ -338,7 +338,7 @@ describe("AbilitySaveMessage no legit active effects", () => {
 
     new AbilitySaveMessage(actor, "int").addMessage(options);
 
-    expect(options.dialogOptions).toBeUndefined();
+    expect(options.options).toBeUndefined();
   });
 });
 
@@ -349,7 +349,7 @@ describe("AbilitySaveMessage message flags", () => {
 
     new AbilitySaveMessage(actor, "int").addMessage(options);
 
-    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual(["message.all message"]);
+    expect(options.options["adv-reminder"].messages).toStrictEqual(["message.all message"]);
   });
 
   test("saving throw with message.ability.all flag should add the message", () => {
@@ -361,7 +361,7 @@ describe("AbilitySaveMessage message flags", () => {
 
     new AbilitySaveMessage(actor, "int").addMessage(options);
 
-    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual([
+    expect(options.options["adv-reminder"].messages).toStrictEqual([
       "message.ability.all message",
     ]);
   });
@@ -375,7 +375,7 @@ describe("AbilitySaveMessage message flags", () => {
 
     new AbilitySaveMessage(actor, "int").addMessage(options);
 
-    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual([
+    expect(options.options["adv-reminder"].messages).toStrictEqual([
       "message.ability.save.all message",
     ]);
   });
@@ -389,7 +389,7 @@ describe("AbilitySaveMessage message flags", () => {
 
     new AbilitySaveMessage(actor, "int").addMessage(options);
 
-    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual([
+    expect(options.options["adv-reminder"].messages).toStrictEqual([
       "message.ability.save.int message",
     ]);
   });
@@ -403,7 +403,7 @@ describe("AbilitySaveMessage message flags", () => {
 
     new AbilitySaveMessage(actor, "dex").addMessage(options);
 
-    expect(options.dialogOptions).toBeUndefined();
+    expect(options.options).toBeUndefined();
   });
 
   test("saving throw with two messages should add both messages", () => {
@@ -415,7 +415,7 @@ describe("AbilitySaveMessage message flags", () => {
 
     new AbilitySaveMessage(actor, "dex").addMessage(options);
 
-    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual(["first", "second"]);
+    expect(options.options["adv-reminder"].messages).toStrictEqual(["first", "second"]);
   });
 });
 
@@ -426,7 +426,7 @@ describe("SkillMessage no legit active effects", () => {
 
     new SkillMessage(actor, "str", "ath").addMessage(options);
 
-    expect(options.dialogOptions).toBeUndefined();
+    expect(options.options).toBeUndefined();
   });
 });
 
@@ -437,7 +437,7 @@ describe("SkillMessage message flags", () => {
 
     new SkillMessage(actor, "wis", "prc").addMessage(options);
 
-    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual(["message.all message"]);
+    expect(options.options["adv-reminder"].messages).toStrictEqual(["message.all message"]);
   });
 
   test("skill check with message.ability.all flag should add the message", () => {
@@ -449,7 +449,7 @@ describe("SkillMessage message flags", () => {
 
     new SkillMessage(actor, "wis", "prc").addMessage(options);
 
-    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual([
+    expect(options.options["adv-reminder"].messages).toStrictEqual([
       "message.ability.all message",
     ]);
   });
@@ -463,7 +463,7 @@ describe("SkillMessage message flags", () => {
 
     new SkillMessage(actor, "wis", "prc").addMessage(options);
 
-    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual([
+    expect(options.options["adv-reminder"].messages).toStrictEqual([
       "message.ability.check.all message",
     ]);
   });
@@ -477,7 +477,7 @@ describe("SkillMessage message flags", () => {
 
     new SkillMessage(actor, "wis", "prc").addMessage(options);
 
-    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual([
+    expect(options.options["adv-reminder"].messages).toStrictEqual([
       "message.ability.check.int message",
     ]);
   });
@@ -491,7 +491,7 @@ describe("SkillMessage message flags", () => {
 
     new SkillMessage(actor, "dex", "acr").addMessage(options);
 
-    expect(options.dialogOptions).toBeUndefined();
+    expect(options.options).toBeUndefined();
   });
 
   test("skill check with message.skill.all flag should add the message", () => {
@@ -503,7 +503,7 @@ describe("SkillMessage message flags", () => {
 
     new SkillMessage(actor, "wis", "prc").addMessage(options);
 
-    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual([
+    expect(options.options["adv-reminder"].messages).toStrictEqual([
       "message.skill.all message",
     ]);
   });
@@ -517,7 +517,7 @@ describe("SkillMessage message flags", () => {
 
     new SkillMessage(actor, "wis", "prc").addMessage(options);
 
-    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual([
+    expect(options.options["adv-reminder"].messages).toStrictEqual([
       "message.skill.prc message",
     ]);
   });
@@ -531,7 +531,7 @@ describe("SkillMessage message flags", () => {
 
     new SkillMessage(actor, "int", "nat").addMessage(options);
 
-    expect(options.dialogOptions).toBeUndefined();
+    expect(options.options).toBeUndefined();
   });
 
   test("skill check with two messages should add both messages", () => {
@@ -543,7 +543,7 @@ describe("SkillMessage message flags", () => {
 
     new SkillMessage(actor, "dex", "ste").addMessage(options);
 
-    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual(["first", "second"]);
+    expect(options.options["adv-reminder"].messages).toStrictEqual(["first", "second"]);
   });
 });
 
@@ -554,7 +554,7 @@ describe("DeathSaveMessage no legit active effects", () => {
 
     new DeathSaveMessage(actor).addMessage(options);
 
-    expect(options.dialogOptions).toBeUndefined();
+    expect(options.options).toBeUndefined();
   });
 });
 
@@ -565,7 +565,7 @@ describe("DeathSaveMessage message flags", () => {
 
     new DeathSaveMessage(actor).addMessage(options);
 
-    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual(["message.all message"]);
+    expect(options.options["adv-reminder"].messages).toStrictEqual(["message.all message"]);
   });
 
   test("death save with message.ability.all flag should add the message", () => {
@@ -577,7 +577,7 @@ describe("DeathSaveMessage message flags", () => {
 
     new DeathSaveMessage(actor).addMessage(options);
 
-    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual([
+    expect(options.options["adv-reminder"].messages).toStrictEqual([
       "message.ability.all message",
     ]);
   });
@@ -591,7 +591,7 @@ describe("DeathSaveMessage message flags", () => {
 
     new DeathSaveMessage(actor).addMessage(options);
 
-    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual([
+    expect(options.options["adv-reminder"].messages).toStrictEqual([
       "message.ability.save.all message",
     ]);
   });
@@ -605,7 +605,7 @@ describe("DeathSaveMessage message flags", () => {
 
     new DeathSaveMessage(actor).addMessage(options);
 
-    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual([
+    expect(options.options["adv-reminder"].messages).toStrictEqual([
       "message.deathSave message",
     ]);
   });
@@ -619,7 +619,7 @@ describe("DeathSaveMessage message flags", () => {
 
     new DeathSaveMessage(actor).addMessage(options);
 
-    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual(["first", "second"]);
+    expect(options.options["adv-reminder"].messages).toStrictEqual(["first", "second"]);
   });
 });
 
@@ -631,7 +631,7 @@ describe("DamageMessage no legit active effects", () => {
 
     new DamageMessage(actor, undefined, item).addMessage(options);
 
-    expect(options.dialogOptions).toBeUndefined();
+    expect(options.options).toBeUndefined();
   });
 });
 
@@ -643,7 +643,7 @@ describe("DamageMessage message flags", () => {
 
     new DamageMessage(actor, undefined, item).addMessage(options);
 
-    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual(["message.all message"]);
+    expect(options.options["adv-reminder"].messages).toStrictEqual(["message.all message"]);
   });
 
   test("damage with message.damage.all flag should add the message", () => {
@@ -656,7 +656,7 @@ describe("DamageMessage message flags", () => {
 
     new DamageMessage(actor, undefined, item).addMessage(options);
 
-    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual([
+    expect(options.options["adv-reminder"].messages).toStrictEqual([
       "message.damage.all message",
     ]);
   });
@@ -671,7 +671,7 @@ describe("DamageMessage message flags", () => {
 
     new DamageMessage(actor, undefined, item).addMessage(options);
 
-    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual([
+    expect(options.options["adv-reminder"].messages).toStrictEqual([
       "message.damage.mwak message",
     ]);
   });
@@ -686,7 +686,7 @@ describe("DamageMessage message flags", () => {
 
     new DamageMessage(actor, undefined, item).addMessage(options);
 
-    expect(options.dialogOptions).toBeUndefined();
+    expect(options.options).toBeUndefined();
   });
 
   test("damage with two messages should add both messages", () => {
@@ -699,7 +699,7 @@ describe("DamageMessage message flags", () => {
 
     new DamageMessage(actor, undefined, item).addMessage(options);
 
-    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual(["first", "second"]);
+    expect(options.options["adv-reminder"].messages).toStrictEqual(["first", "second"]);
   });
 });
 
@@ -715,7 +715,7 @@ describe("DamageMessage from target", () => {
 
     new DamageMessage(actor, target, item).addMessage(options);
 
-    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual([
+    expect(options.options["adv-reminder"].messages).toStrictEqual([
       "message.damage.all message",
     ]);
   });
@@ -731,7 +731,7 @@ describe("DamageMessage from target", () => {
 
     new DamageMessage(actor, target, item).addMessage(options);
 
-    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual([
+    expect(options.options["adv-reminder"].messages).toStrictEqual([
       "message.damage.mwak message",
     ]);
   });
@@ -747,7 +747,7 @@ describe("DamageMessage from target", () => {
 
     new DamageMessage(actor, target, item).addMessage(options);
 
-    expect(options.dialogOptions).toBeUndefined();
+    expect(options.options).toBeUndefined();
   });
 
   test("damage with two messages should add both messages", () => {
@@ -761,6 +761,6 @@ describe("DamageMessage from target", () => {
 
     new DamageMessage(actor, target, item).addMessage(options);
 
-    expect(options.dialogOptions["adv-reminder"].messages).toStrictEqual(["first", "second"]);
+    expect(options.options["adv-reminder"].messages).toStrictEqual(["first", "second"]);
   });
 });


### PR DESCRIPTION
restore skill/save/ability functionality in dnd 4.1.2.
However, some code cleanup is necessary and the damage critical feature does not work. (the function had not worked for me before)
There is currently no separate reminder for tools, only the one via ability. I have therefore commented out the hook for now.
Since I don't use dae, midi or rsr, I only touched on the core functionalities (as well as the midi flag reminder)

For the fix, I've focused on functionality rather than beauty. If I get the chance, I can do a little clean-up here too, if you want.