### PR TITLE
Fix sample roll and use advantage from options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 4.2.5
 
 - bug fix: Advantage not being passed on in a few cases that the system does it (e.g. initiative)
+- bug fix: [#99](https://github.com/kaelad02/adv-reminder/issues/99) Sample roll in settings not working
 
 # 4.2.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.2.5
+
+- bug fix: Advantage not being passed on in a few cases that the system does it (e.g. initiative)
+
 # 4.2.4
 
 - bug fix: [#95](https://github.com/kaelad02/adv-reminder/issues/95) Default button is black when using player color

--- a/src/reminders.js
+++ b/src/reminders.js
@@ -134,7 +134,7 @@ export class AttackReminder extends BaseReminder {
       disConditions.push("advReminderDisadvantagePhysicalRolls");
 
     // find matching keys
-    const accumulator = this._accumulator();
+    const accumulator = this._accumulator(options);
     accumulator.add(this.actorFlags, advKeys, disKeys);
     accumulator.add(this.targetFlags, grantsAdvKeys, grantsDisKeys);
     // handle status effects
@@ -194,7 +194,7 @@ class AbilityBaseReminder extends BaseReminder {
     debug("advKeys", advKeys, "disKeys", disKeys);
 
     // find matching keys, status effects, and update options
-    const accumulator = options.isConcentration ? this._accumulator(options) : this._accumulator();
+    const accumulator = this._accumulator(options);
     accumulator.add(this.actorFlags, advKeys, disKeys);
     accumulator.fromConditions(this.actor, this.advantageConditions, this.disadvantageConditions);
     accumulator.update(options);
@@ -292,7 +292,7 @@ export class SkillReminder extends AbilityCheckReminder {
     debug("advKeys", advKeys, "disKeys", disKeys);
 
     // find matching keys and update options
-    const accumulator = this._accumulator();
+    const accumulator = this._accumulator(options);
     if (this.checkArmorStealth) {
       accumulator.disadvantage(this._armorStealthDisadvantage());
     }

--- a/src/settings.js
+++ b/src/settings.js
@@ -178,7 +178,9 @@ class MessageColorSettings extends FormApplication {
     debug("_onTest called");
     event.preventDefault();
 
-    const rollConfig = { rolls: [{ parts: ["@mod", "@prof"], data: { mod: 3, prof: 2 } }] };
+    const rollConfig = {
+      rolls: [{ parts: ["@mod", "@prof"], data: { mod: 3, prof: 2 }, options: {} }],
+    };
     const dialogConfig = {
       options: { "adv-reminder": { messages: ["Conditional bonus [[/r +2]]"] } },
     };


### PR DESCRIPTION
- fix #99: the sample roll in the settings needs an empty `rolls[0].options` object in 4.3 (maybe 4.2 too)
- Grab advantage/disadvantage from the roll options on all rolls, not just concentration. Useful for initiative and death saving throws now, might be useful for 4.4 in the future.