### PR TITLE
RSR compatibility updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 5.0.2
+
+- feature: update RSR compatibility with more accurate message, source, and reminder processing
+- feature: update RSR compatibility with critical hits, if a reminder set `isCritical` the RSR chat message correctly shows it
+
 # 5.0.1
 
 - feature: add some checks to reminders and sources that the Midi flag is actually true, mainly for some edge cases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 5.0.2
 
-- feature: update RSR compatibility with more accurate message, source, and reminder processing
+- feature: update RSR compatibility with more accurate message, source, and reminder processing, tested with version 3.5.0
 - feature: update RSR compatibility with critical hits, if a reminder set `isCritical` the RSR chat message correctly shows it
 
 # 5.0.1

--- a/README.md
+++ b/README.md
@@ -71,5 +71,4 @@ If the player holds down one of the Ctrl/Alt/Shift/Meta keys to fast-forward the
 [Ready Set Roll for D&D5e](https://foundryvtt.com/packages/ready-set-roll-5e) This module works with Ready Set Roll with the following notes:
 
 - This module will apply advantage/disadvantage on checks even if RSR is configured for quick rolls. This is skipped if you hold down one of the roll modifier keys to manually apply advantage/disadvantage (similar to core behavior). 
-- Effects for critical hits work but not those that cancel crits because of how early this module has to set the `isCrit` flag
 - Does not show messages if RSR is configured for quick rolls since there is no dialog to show them

--- a/src/rollers/rsr.js
+++ b/src/rollers/rsr.js
@@ -13,6 +13,7 @@ import {
   AttackReminder,
   AbilityCheckReminder,
   AbilitySaveReminder,
+  ConcentrationReminder,
   CriticalReminder,
   DeathSaveReminder,
   SkillReminder,
@@ -86,12 +87,13 @@ export default class ReadySetRollHooks extends CoreRollerHooks {
     if (config[CoreRollerHooks.PROCESSED_PROP]) return;
     config[CoreRollerHooks.PROCESSED_PROP] = true;
 
+    const actor = config.subject;
+    const abilityId = config.ability;
     if (this._doMessages(dialog)) {
-      const actor = config.subject;
-      new ConcentrationMessage(actor, config.ability).addMessage(dialog);
-      if (showSources) new ConcentrationSource(actor, config.ability).updateOptions(dialog);
+      new ConcentrationMessage(actor, abilityId).addMessage(dialog);
+      if (showSources) new ConcentrationSource(actor, abilityId).updateOptions(dialog);
     }
-    // don't need a reminder, the system will set advantage/disadvantage
+    if (this._doReminder(message)) new ConcentrationReminder(actor, abilityId).updateOptions(config.rolls[0].options);
   }
 
   preRollAbilityCheckV2(config, dialog, message) {


### PR DESCRIPTION
Tested with RSR 3.5.0 on Foundry v13 to update compatibility, yet again

- more accurate message, source, and reminder processing, tested with version 3.5.0
- correctly process critical reminders, if a reminder set `isCritical` the RSR chat message correctly shows it
