### PR TITLE
Update condition effects from 5.1 changes

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -73,7 +73,7 @@ function updateConditionEffects() {
   ce.advReminderGrantAdjacentAttack = new Set(["prone"]);
 
   if (game.settings.get("dnd5e", "rulesVersion") === "legacy")
-    ce.advReminderGrantDisadvantageAttack.add("exhaustion-3");
+    ce.advReminderDisadvantageAttack.add("exhaustion-3");
 }
 
 Hooks.once("ready", () => {

--- a/src/module.js
+++ b/src/module.js
@@ -63,9 +63,6 @@ function updateConditionEffects() {
   ce.advReminderAdvantageAttack = new Set(["hiding", "invisible"]);
   ce.advReminderAdvantageDexSave = new Set(["dodging"]); 
   ce.advReminderDisadvantageAttack = new Set(["blinded", "frightened", "poisoned", "prone", "restrained"]);
-  ce.advReminderDisadvantageAbility = new Set(["frightened", "poisoned"]);
-  ce.advReminderDisadvantageSave = new Set();
-  ce.advReminderDisadvantageDexSave = new Set(["restrained"]);
   ce.advReminderDisadvantagePhysicalRolls = new Set(["heavilyEncumbered"]);
   ce.advReminderFailDexSave = new Set(["paralyzed", "petrified", "stunned", "unconscious"]);
   ce.advReminderFailStrSave = new Set(["paralyzed", "petrified", "stunned", "unconscious"]);
@@ -75,14 +72,8 @@ function updateConditionEffects() {
   // if adjacent, grant advantage on the attack, else grant disadvantage
   ce.advReminderGrantAdjacentAttack = new Set(["prone"]);
 
-  if (game.settings.get("dnd5e", "rulesVersion") === "legacy") {
-    ce.advReminderDisadvantageAbility.add("exhaustion-1");
-    ce.advReminderDisadvantageSave.add("exhaustion-3");
+  if (game.settings.get("dnd5e", "rulesVersion") === "legacy")
     ce.advReminderGrantDisadvantageAttack.add("exhaustion-3");
-  } else {
-    ce.advReminderAdvantageInitiative = new Set(["invisible"]);
-    ce.advReminderDisadvantageInitiative = new Set(["incapacitated", "surprised"]);
-  }
 }
 
 Hooks.once("ready", () => {

--- a/src/reminders.js
+++ b/src/reminders.js
@@ -350,12 +350,6 @@ export class AbilityCheckReminder extends AbilityBaseReminder {
     ]);
   }
 
-  get disadvantageConditions() {
-    const conditions = super.disadvantageConditions;
-    conditions.push("advReminderDisadvantageAbility");
-    return conditions;
-  }
-
   get rollModes() {
     const abilityLabel = CONFIG.DND5E.abilities[this.abilityId]?.label ?? "";
 
@@ -404,13 +398,6 @@ export class AbilitySaveReminder extends AbilityBaseReminder {
   get advantageConditions() {
     const conditions = [];
     if (this.abilityId === "dex") conditions.push("advReminderAdvantageDexSave");
-    return conditions;
-  }
-
-  get disadvantageConditions() {
-    const conditions = super.disadvantageConditions;
-    conditions.push("advReminderDisadvantageSave");
-    if (this.abilityId === "dex") conditions.push("advReminderDisadvantageDexSave");
     return conditions;
   }
 
@@ -518,14 +505,6 @@ export class ToolReminder extends AbilityCheckReminder {
 }
 
 export class InitiativeReminder extends AbilityCheckReminder {
-  get advantageConditions() {
-    return super.advantageConditions.concat("advReminderAdvantageInitiative");
-  }
-
-  get disadvantageConditions() {
-    return super.disadvantageConditions.concat("advReminderDisadvantageInitiative");
-  }
-
   get rollModes() {
     const modes = super.rollModes;
     modes["system.attributes.init.roll.mode"] = "DND5E.Initiative";

--- a/src/settings.js
+++ b/src/settings.js
@@ -64,7 +64,7 @@ export function initSettings() {
     config: true,
     requiresReload: true,
     type: Boolean,
-    default: false,
+    default: true,
   });
 
   // Hidden debugMode setting

--- a/src/sources.js
+++ b/src/sources.js
@@ -197,17 +197,35 @@ const SourceMixin = (superclass) =>
 
 export class AttackSource extends SourceMixin(AttackReminder) {}
 
-export class AbilitySaveSource extends SourceMixin(AbilitySaveReminder) {}
+export class AbilitySaveSource extends SourceMixin(AbilitySaveReminder) {
+  get disadvantageConditions() {
+    const conditions = ["abilitySaveDisadvantage"];
+    if (this.abilityId === "dex") conditions.push("dexteritySaveDisadvantage");
+    return super.disadvantageConditions.concat(conditions);
+  }
+}
 
 export class ConcentrationSource extends SourceMixin(ConcentrationReminder) {}
 
-export class AbilityCheckSource extends SourceMixin(AbilityCheckReminder) {}
+export class AbilityCheckSource extends SourceMixin(AbilityCheckReminder) {
+  get disadvantageConditions() {
+    return super.disadvantageConditions.concat("abilityCheckDisadvantage");
+  }
+}
 
 export class SkillSource extends SourceMixin(SkillReminder) {}
 
 export class ToolSource extends SourceMixin(ToolReminder) {}
 
 export class InitiativeSource extends SourceMixin(InitiativeReminder) {
+  get advantageConditions() {
+    return super.advantageConditions.concat("initiativeAdvantage");
+  }
+
+  get disadvantageConditions() {
+    return super.disadvantageConditions.concat("initiativeDisadvantage");
+  }
+
   _customUpdateOptions(accumulator) {
     super._customUpdateOptions(accumulator);
 


### PR DESCRIPTION
5.1 added some new `conditionEffects` that apply advantage/disadvantage to ability checks, saving throws, and initiative rolls. They overlapped what this module did, so remove those I added and add source attribution for what the system has.

Make the `updateStatusEffects` setting default to true now. Now that 5.1 makes some of these statuses apply adv/dis, let's turn these on by default to match. Still worth having a setting, but let's make it on by default.