### PR TITLE
Move armor's stealthDisadvantage check from the reminder to source

### DIFF
--- a/src/reminders.js
+++ b/src/reminders.js
@@ -435,15 +435,13 @@ export class ConcentrationReminder extends AbilitySaveReminder {
 }
 
 export class SkillReminder extends AbilityCheckReminder {
-  constructor(actor, abilityId, skillId, checkArmorStealth = true) {
+  constructor(actor, abilityId, skillId) {
     super(actor, abilityId);
 
     /** @type {string} */
     this.skillId = skillId;
     /** @type {Item5e[]} */
     this.items = actor.items;
-    /** @type {boolean} */
-    this.checkArmorStealth = checkArmorStealth;
   }
 
   /** @override */
@@ -468,19 +466,6 @@ export class SkillReminder extends AbilityCheckReminder {
       data: { label: skillLabel }
     };
     return modes;
-  }
-
-  _customUpdateOptions(accumulator) {
-    super._customUpdateOptions(accumulator);
-
-    // Check if the actor is wearing armor that imposes stealth disadvantage
-    if (this.checkArmorStealth && this.skillId === "ste") {
-      const item = this.items.find(
-        (item) => item.type === "equipment" && item.system.equipped && item.system.properties.has("stealthDisadvantage")
-      );
-      debug("equipped item that imposes stealth disadvantage", item?.name);
-      accumulator.disadvantage(item?.link);
-    }
   }
 }
 

--- a/src/reminders.js
+++ b/src/reminders.js
@@ -440,8 +440,6 @@ export class SkillReminder extends AbilityCheckReminder {
 
     /** @type {string} */
     this.skillId = skillId;
-    /** @type {Item5e[]} */
-    this.items = actor.items;
   }
 
   /** @override */

--- a/src/rollers/core.js
+++ b/src/rollers/core.js
@@ -45,19 +45,9 @@ export default class CoreRollerHooks {
   static PROCESSED_PROP = "adv-reminder-processed";
 
   /**
-   * If true, check armor for stealth checks.
-   * @type {boolean}
-   */
-  checkArmorStealth;
-
-  /**
    * Initialize the hooks.
    */
   init() {
-    // DAE version 0.8.81 added support for "impose stealth disadvantage"
-    this.checkArmorStealth = !game.modules.get("dae")?.active;
-    debug("checkArmorStealth", this.checkArmorStealth);
-
     // register all the dnd5e.pre hooks
     Hooks.on("dnd5e.preRollAttackV2", this.preRollAttackV2.bind(this));
     Hooks.on("dnd5e.preRollSavingThrowV2", this.preRollSavingThrowV2.bind(this));
@@ -158,8 +148,8 @@ export default class CoreRollerHooks {
     const ability = config.ability;
     const skillId = config.skill;
     new SkillMessage(actor, ability, skillId).addMessage(dialog);
-    if (showSources) new SkillSource(actor, ability, skillId, true).updateOptions(dialog);
-    new SkillReminder(actor, ability, skillId, this.checkArmorStealth).updateOptions(config.rolls[0].options);
+    if (showSources) new SkillSource(actor, ability, skillId).updateOptions(dialog);
+    new SkillReminder(actor, ability, skillId).updateOptions(config.rolls[0].options);
   }
 
   preRollToolV2(config, dialog, message) {

--- a/src/rollers/midi.js
+++ b/src/rollers/midi.js
@@ -165,7 +165,7 @@ export default class MidiRollerHooks extends CoreRollerHooks {
     const ability = config.ability;
     const skillId = config.skill;
     new SkillMessage(actor, ability, skillId).addMessage(dialog);
-    if (showSources) new MidiSkillSource(actor, ability, skillId, true).updateOptions(dialog);
+    if (showSources) new MidiSkillSource(actor, ability, skillId).updateOptions(dialog);
   }
 
   preRollToolV2(config, dialog, message) {

--- a/src/rollers/rsr.js
+++ b/src/rollers/rsr.js
@@ -134,11 +134,11 @@ export default class ReadySetRollHooks extends CoreRollerHooks {
     const skillId = config.skill;
     if (this._doMessages(config, dialog)) {
       new SkillMessage(actor, ability, skillId).addMessage(dialog);
-      if (showSources) new SkillSource(actor, ability, skillId, true).updateOptions(dialog);
+      if (showSources) new SkillSource(actor, ability, skillId).updateOptions(dialog);
     }
 
     if (this._doReminder(config, dialog, message))
-      new SkillReminder(actor, ability, skillId, this.checkArmorStealth).updateOptions(config.rolls[0].options);
+      new SkillReminder(actor, ability, skillId).updateOptions(config.rolls[0].options);
   }
 
   preRollToolV2(config, dialog, message) {

--- a/src/sources.js
+++ b/src/sources.js
@@ -213,7 +213,21 @@ export class AbilityCheckSource extends SourceMixin(AbilityCheckReminder) {
   }
 }
 
-export class SkillSource extends SourceMixin(SkillReminder) {}
+export class SkillSource extends SourceMixin(SkillReminder) {
+  _customUpdateOptions(accumulator) {
+    super._customUpdateOptions(accumulator);
+
+    // similar to what AttributesFields#prepareArmorClass does
+    // Check for stealth disadvantage from armor
+    if (this.skillId === "ste") {
+      const armors = this.actor.itemTypes.equipment
+        .filter(equip => equip.system.equipped && equip.system.type.value in CONFIG.DND5E.armorTypes)
+        .filter(equip => equip.system.type.value !== "shield");
+      if (armors[0]?.system.properties.has("stealthDisadvantage"))
+        accumulator.disadvantage(armors[0].link);
+    }
+  }
+}
 
 export class ToolSource extends SourceMixin(ToolReminder) {}
 

--- a/test/reminders.test.js
+++ b/test/reminders.test.js
@@ -729,48 +729,6 @@ describe("SkillReminder no legit active effects", () => {
     expect(options.advantage).toBe(false);
     expect(options.disadvantage).toBe(false);
   });
-
-  test("Stealth check with armor that imposes disadvantage but wrong type", () => {
-    const actor = createActorWithFlags();
-    actor.items = [
-      {
-        name: "Scale Mail",
-        type: "spell",
-        system: {
-          equipped: true,
-          properties: new Set(["stealthDisadvantage"]),
-        },
-      },
-    ];
-    const options = {};
-
-    const reminder = new SkillReminder(actor, "dex", "ste");
-    reminder.updateOptions(options);
-
-    expect(options.advantage).toBe(false);
-    expect(options.disadvantage).toBe(false);
-  });
-
-  test("Stealth check with armor that imposes disadvantage but not equipped", () => {
-    const actor = createActorWithFlags();
-    actor.items = [
-      {
-        name: "Scale Mail",
-        type: "equipment",
-        system: {
-          equipped: false,
-          properties: new Set(["stealthDisadvantage"]),
-        },
-      },
-    ];
-    const options = {};
-
-    const reminder = new SkillReminder(actor, "dex", "ste");
-    reminder.updateOptions(options);
-
-    expect(options.advantage).toBe(false);
-    expect(options.disadvantage).toBe(false);
-  });
 });
 
 describe("SkillReminder advantage flags", () => {
@@ -946,49 +904,6 @@ describe("SkillReminder disadvantage flags", () => {
     const options = {};
 
     const reminder = new SkillReminder(actor, "int", "arc");
-    reminder.updateOptions(options);
-
-    expect(options.advantage).toBe(false);
-    expect(options.disadvantage).toBe(false);
-  });
-
-  test("Stealth check with armor that imposes disadvantage", () => {
-    const actor = createActorWithFlags();
-    actor.items = [
-      {
-        name: "Scale Mail",
-        type: "equipment",
-        system: {
-          equipped: true,
-          properties: new Set(["stealthDisadvantage"]),
-        },
-        link: "@UUID[fake-uuid]{Scale Mail}",
-      },
-    ];
-    const options = {};
-
-    const reminder = new SkillReminder(actor, "dex", "ste");
-    reminder.updateOptions(options);
-
-    expect(options.advantage).toBe(false);
-    expect(options.disadvantage).toBe(true);
-  });
-
-  test("Stealth check with armor that imposes disadvantage but checking is off", () => {
-    const actor = createActorWithFlags();
-    actor.items = [
-      {
-        name: "Scale Mail",
-        type: "equipment",
-        system: {
-          equipped: true,
-          properties: new Set(["stealthDisadvantage"]),
-        },
-      },
-    ];
-    const options = {};
-
-    const reminder = new SkillReminder(actor, "dex", "ste", false);
     reminder.updateOptions(options);
 
     expect(options.advantage).toBe(false);


### PR DESCRIPTION
The system now applies `stealthDisadvantage` from armor now, so there's no need to include it in `SkillReminder`. Remove it from the reminder but add a check in `SkillSource` to make sure source attribution for it still works.