### PR TITLE
Handle double proficiency and pace on skill and tool checks

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -52,7 +52,8 @@
     "Advantage": {
       "override": "Advantage Override from",
       "suppressed": "Advantage Suppressed by",
-      "prefix": "Advantage from"
+      "prefix": "Advantage from",
+      "doubleProf": "Double Proficiency"
     },
     "Normal": {
       "override": "Normal Override from"

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -51,7 +51,8 @@
     "Advantage": {
       "override": "Source de la priorité d'avantage :",
       "suppressed": "Source de l'avantage supprimé :",
-      "prefix": "Source de l'avantage :"
+      "prefix": "Source de l'avantage :",
+      "doubleProf": "Double compétence"
     },
     "Normal": {
       "override": "Source de la priorité normal :"

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -54,7 +54,8 @@
     "Advantage": {
       "override": "Vantagem anulada por",
       "suppressed": "Vantagem suprimida por",
-      "prefix": "Vantagem de"
+      "prefix": "Vantagem de",
+      "doubleProf": "Proficiência Dupla"
     },
     "Normal": {
       "override": "Substituição normal de"

--- a/src/reminders.js
+++ b/src/reminders.js
@@ -435,11 +435,15 @@ export class ConcentrationReminder extends AbilitySaveReminder {
 }
 
 export class SkillReminder extends AbilityCheckReminder {
-  constructor(actor, abilityId, skillId) {
+  constructor(actor, abilityId, skillId, doubleProf, pace) {
     super(actor, abilityId);
 
     /** @type {string} */
     this.skillId = skillId;
+    /** @type {boolean} */
+    this.doubleProf = doubleProf;
+    /** @type {{ advantage: boolean, disadvantage: boolean }} */
+    this.pace = pace;
   }
 
   /** @override */
@@ -465,14 +469,27 @@ export class SkillReminder extends AbilityCheckReminder {
     };
     return modes;
   }
+
+  _customUpdateOptions(accumulator) {
+    super._customUpdateOptions(accumulator);
+
+    if (this.doubleProf) {
+      const label = game.i18n.localize("adv-reminder.Source.Advantage.doubleProf");
+      accumulator.advantage(label);
+    }
+    if (this.pace?.advantage) accumulator.advantage("&Reference[travelpace]");
+    if (this.pace?.disadvantage) accumulator.disadvantage("&Reference[travelpace]");
+  }
 }
 
 export class ToolReminder extends AbilityCheckReminder {
-  constructor(actor, abilityId, toolId) {
+  constructor(actor, abilityId, toolId, doubleProf) {
     super(actor, abilityId);
 
     /** @type {string} */
     this.toolId = toolId;
+    /** @type {boolean} */
+    this.doubleProf = doubleProf;
   }
 
   get rollModes() {
@@ -484,6 +501,15 @@ export class ToolReminder extends AbilityCheckReminder {
       data: { label: toolLabel }
     };
     return modes;
+  }
+
+  _customUpdateOptions(accumulator) {
+    super._customUpdateOptions(accumulator);
+
+    if (this.doubleProf) {
+      const label = game.i18n.localize("adv-reminder.Source.Advantage.doubleProf");
+      accumulator.advantage(label);
+    }
   }
 }
 

--- a/src/rollers/core.js
+++ b/src/rollers/core.js
@@ -151,7 +151,7 @@ export default class CoreRollerHooks {
     const pace = dnd5e.dataModels.shared.MovementField.getTravelPaceMode(config.pace, config.skill);
     new SkillMessage(actor, ability, skillId).addMessage(dialog);
     if (showSources) new SkillSource(actor, ability, skillId, doubleProf, pace).updateOptions(dialog);
-    new SkillReminder(actor, ability, skillId).updateOptions(config.rolls[0].options);
+    new SkillReminder(actor, ability, skillId, doubleProf, pace).updateOptions(config.rolls[0].options);
   }
 
   preRollToolV2(config, dialog, message) {
@@ -169,7 +169,7 @@ export default class CoreRollerHooks {
     const doubleProf = this.isDoubleProf(config);
     new ToolMessage(actor, ability, toolId).addMessage(dialog);
     if (showSources) new ToolSource(actor, ability, toolId, doubleProf).updateOptions(dialog);
-    new ToolReminder(actor, ability, toolId).updateOptions(config.rolls[0].options);
+    new ToolReminder(actor, ability, toolId, doubleProf).updateOptions(config.rolls[0].options);
   }
 
   preRollInitiativeDialogV2(config, dialog, message) {

--- a/src/rollers/core.js
+++ b/src/rollers/core.js
@@ -148,8 +148,9 @@ export default class CoreRollerHooks {
     const ability = config.ability;
     const skillId = config.skill;
     const doubleProf = this.isDoubleProf(config);
+    const pace = dnd5e.dataModels.shared.MovementField.getTravelPaceMode(config.pace, config.skill);
     new SkillMessage(actor, ability, skillId).addMessage(dialog);
-    if (showSources) new SkillSource(actor, ability, skillId, doubleProf).updateOptions(dialog);
+    if (showSources) new SkillSource(actor, ability, skillId, doubleProf, pace).updateOptions(dialog);
     new SkillReminder(actor, ability, skillId).updateOptions(config.rolls[0].options);
   }
 

--- a/src/rollers/core.js
+++ b/src/rollers/core.js
@@ -147,8 +147,9 @@ export default class CoreRollerHooks {
     const actor = config.subject;
     const ability = config.ability;
     const skillId = config.skill;
+    const doubleProf = this.isDoubleProf(config);
     new SkillMessage(actor, ability, skillId).addMessage(dialog);
-    if (showSources) new SkillSource(actor, ability, skillId).updateOptions(dialog);
+    if (showSources) new SkillSource(actor, ability, skillId, doubleProf).updateOptions(dialog);
     new SkillReminder(actor, ability, skillId).updateOptions(config.rolls[0].options);
   }
 
@@ -235,5 +236,13 @@ export default class CoreRollerHooks {
     configure ??= !Object.values(keys).some(k => k);
     if (!configure) debug("fast-forwarding the roll, stop processing");
     return !configure;
+  }
+
+  isDoubleProf(config) {
+    const actor = config.subject;
+    const skill = actor.system.skills?.[config.skill];
+    const tool = actor.system.tools?.[config.tool];
+    debug("isDoubleProf", skill, tool);
+    return !!skill?.prof.hasProficiency && !!tool?.prof.hasProficiency;
   }
 }

--- a/src/rollers/core.js
+++ b/src/rollers/core.js
@@ -165,8 +165,9 @@ export default class CoreRollerHooks {
     const actor = config.subject;
     const ability = config.ability;
     const toolId = config.tool;
+    const doubleProf = this.isDoubleProf(config);
     new ToolMessage(actor, ability, toolId).addMessage(dialog);
-    if (showSources) new ToolSource(actor, ability, toolId).updateOptions(dialog);
+    if (showSources) new ToolSource(actor, ability, toolId, doubleProf).updateOptions(dialog);
     new ToolReminder(actor, ability, toolId).updateOptions(config.rolls[0].options);
   }
 

--- a/src/rollers/midi.js
+++ b/src/rollers/midi.js
@@ -164,8 +164,10 @@ export default class MidiRollerHooks extends CoreRollerHooks {
     const actor = config.subject;
     const ability = config.ability;
     const skillId = config.skill;
+    const doubleProf = this.isDoubleProf(config);
+    const pace = dnd5e.dataModels.shared.MovementField.getTravelPaceMode(config.pace, config.skill);
     new SkillMessage(actor, ability, skillId).addMessage(dialog);
-    if (showSources) new MidiSkillSource(actor, ability, skillId).updateOptions(dialog);
+    if (showSources) new MidiSkillSource(actor, ability, skillId, doubleProf, pace).updateOptions(dialog);
   }
 
   preRollToolV2(config, dialog, message) {
@@ -180,8 +182,9 @@ export default class MidiRollerHooks extends CoreRollerHooks {
     const actor = config.subject;
     const ability = config.ability;
     const toolId = config.tool;
+    const doubleProf = this.isDoubleProf(config);
     new ToolMessage(actor, ability, toolId).addMessage(dialog);
-    if (showSources) new ToolSource(actor, ability, toolId).updateOptions(dialog);
+    if (showSources) new ToolSource(actor, ability, toolId, doubleProf).updateOptions(dialog);
   }
 
   preRollInitiativeDialogV2(config, dialog, message) {

--- a/src/rollers/rsr.js
+++ b/src/rollers/rsr.js
@@ -132,13 +132,15 @@ export default class ReadySetRollHooks extends CoreRollerHooks {
     const actor = config.subject;
     const ability = config.ability;
     const skillId = config.skill;
+    const doubleProf = this.isDoubleProf(config);
+    const pace = dnd5e.dataModels.shared.MovementField.getTravelPaceMode(config.pace, config.skill);
     if (this._doMessages(config, dialog)) {
       new SkillMessage(actor, ability, skillId).addMessage(dialog);
-      if (showSources) new SkillSource(actor, ability, skillId).updateOptions(dialog);
+      if (showSources) new SkillSource(actor, ability, skillId, doubleProf, pace).updateOptions(dialog);
     }
 
     if (this._doReminder(config, dialog, message))
-      new SkillReminder(actor, ability, skillId).updateOptions(config.rolls[0].options);
+      new SkillReminder(actor, ability, skillId, doubleProf, pace).updateOptions(config.rolls[0].options);
   }
 
   preRollToolV2(config, dialog, message) {
@@ -151,13 +153,14 @@ export default class ReadySetRollHooks extends CoreRollerHooks {
     const actor = config.subject;
     const ability = config.ability;
     const toolId = config.tool;
+    const doubleProf = this.isDoubleProf(config);
     if (this._doMessages(config)) {
       new ToolMessage(actor, ability, toolId).addMessage(dialog);
-      if (showSources) new ToolSource(actor, ability, toolId).updateOptions(dialog);
+      if (showSources) new ToolSource(actor, ability, toolId, doubleProf).updateOptions(dialog);
     }
 
     if (this._doReminder(config))
-      new ToolReminder(actor, ability, toolId).updateOptions(config.rolls[0].options);
+      new ToolReminder(actor, ability, toolId, doubleProf).updateOptions(config.rolls[0].options);
   }
 
   preRollInitiativeDialogV2(config, dialog, message) {

--- a/src/sources.js
+++ b/src/sources.js
@@ -241,7 +241,23 @@ export class SkillSource extends SourceMixin(SkillReminder) {
   }
 }
 
-export class ToolSource extends SourceMixin(ToolReminder) {}
+export class ToolSource extends SourceMixin(ToolReminder) {
+  constructor(actor, abilityId, toolId, doubleProf) {
+    super(actor, abilityId, toolId)
+
+    /** @type {boolean} */
+    this.doubleProf = doubleProf;
+  }
+
+  _customUpdateOptions(accumulator) {
+    super._customUpdateOptions(accumulator);
+
+    if (this.doubleProf) {
+      const label = game.i18n.localize("adv-reminder.Source.Advantage.doubleProf");
+      accumulator.advantage(label);
+    }
+  }
+}
 
 export class InitiativeSource extends SourceMixin(InitiativeReminder) {
   get advantageConditions() {

--- a/src/sources.js
+++ b/src/sources.js
@@ -214,6 +214,13 @@ export class AbilityCheckSource extends SourceMixin(AbilityCheckReminder) {
 }
 
 export class SkillSource extends SourceMixin(SkillReminder) {
+  constructor(actor, abilityId, skillId, doubleProf) {
+    super(actor, abilityId, skillId);
+
+    /** @type {boolean} */
+    this.doubleProf = doubleProf;
+  }
+
   _customUpdateOptions(accumulator) {
     super._customUpdateOptions(accumulator);
 
@@ -225,6 +232,11 @@ export class SkillSource extends SourceMixin(SkillReminder) {
         .filter(equip => equip.system.type.value !== "shield");
       if (armors[0]?.system.properties.has("stealthDisadvantage"))
         accumulator.disadvantage(armors[0].link);
+    }
+
+    if (this.doubleProf) {
+      const label = game.i18n.localize("adv-reminder.Source.Advantage.doubleProf");
+      accumulator.advantage(label);
     }
   }
 }

--- a/src/sources.js
+++ b/src/sources.js
@@ -214,15 +214,6 @@ export class AbilityCheckSource extends SourceMixin(AbilityCheckReminder) {
 }
 
 export class SkillSource extends SourceMixin(SkillReminder) {
-  constructor(actor, abilityId, skillId, doubleProf, pace) {
-    super(actor, abilityId, skillId);
-
-    /** @type {boolean} */
-    this.doubleProf = doubleProf;
-    /** @type {{ advantage: boolean, disadvantage: boolean }} */
-    this.pace = pace;
-  }
-
   _customUpdateOptions(accumulator) {
     super._customUpdateOptions(accumulator);
 
@@ -235,33 +226,10 @@ export class SkillSource extends SourceMixin(SkillReminder) {
       if (armors[0]?.system.properties.has("stealthDisadvantage"))
         accumulator.disadvantage(armors[0].link);
     }
-
-    if (this.doubleProf) {
-      const label = game.i18n.localize("adv-reminder.Source.Advantage.doubleProf");
-      accumulator.advantage(label);
-    }
-    if (this.pace.advantage) accumulator.advantage("&Reference[travelpace]");
-    if (this.pace.disadvantage) accumulator.disadvantage("&Reference[travelpace]");
   }
 }
 
-export class ToolSource extends SourceMixin(ToolReminder) {
-  constructor(actor, abilityId, toolId, doubleProf) {
-    super(actor, abilityId, toolId)
-
-    /** @type {boolean} */
-    this.doubleProf = doubleProf;
-  }
-
-  _customUpdateOptions(accumulator) {
-    super._customUpdateOptions(accumulator);
-
-    if (this.doubleProf) {
-      const label = game.i18n.localize("adv-reminder.Source.Advantage.doubleProf");
-      accumulator.advantage(label);
-    }
-  }
-}
+export class ToolSource extends SourceMixin(ToolReminder) {}
 
 export class InitiativeSource extends SourceMixin(InitiativeReminder) {
   get advantageConditions() {

--- a/src/sources.js
+++ b/src/sources.js
@@ -214,11 +214,13 @@ export class AbilityCheckSource extends SourceMixin(AbilityCheckReminder) {
 }
 
 export class SkillSource extends SourceMixin(SkillReminder) {
-  constructor(actor, abilityId, skillId, doubleProf) {
+  constructor(actor, abilityId, skillId, doubleProf, pace) {
     super(actor, abilityId, skillId);
 
     /** @type {boolean} */
     this.doubleProf = doubleProf;
+    /** @type {{ advantage: boolean, disadvantage: boolean }} */
+    this.pace = pace;
   }
 
   _customUpdateOptions(accumulator) {
@@ -238,6 +240,8 @@ export class SkillSource extends SourceMixin(SkillReminder) {
       const label = game.i18n.localize("adv-reminder.Source.Advantage.doubleProf");
       accumulator.advantage(label);
     }
+    if (this.pace.advantage) accumulator.advantage("&Reference[travelpace]");
+    if (this.pace.disadvantage) accumulator.disadvantage("&Reference[travelpace]");
   }
 }
 


### PR DESCRIPTION
Do the double proficiency check to give advantage on skill and tool checks. The `doubleProf` check is done in the roller to simplify the reminder class. I don't like the idea of passing both a skill and tool ID to do the check inside the roller.

Add support for the travel pace too, when making certain skill checks from a party sheet. The question mark in `this.pace?` is done so I don't have to adjust a bunch of unit tests.